### PR TITLE
Fix compilation on macOS

### DIFF
--- a/configparams.cpp
+++ b/configparams.cpp
@@ -27,6 +27,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QBuffer>
+#include <cmath>
 
 ConfigParams::ConfigParams(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
When compiling in Qt Creator on macOS I get the following error

> ../vesc_tool/configparams.cpp:584:12: error: use of undeclared identifier 'fabsf'
    return fabsf(A - B) <= eps * fmaxf(1.0f, fmaxf(fabsf(A), fabsf(B)));
           ^

This pull request fixes it by including the missing header