### PR TITLE
Fix -Wmismatched-new-delete warnings

### DIFF
--- a/digitalfiltering.cpp
+++ b/digitalfiltering.cpp
@@ -137,8 +137,8 @@ void DigitalFiltering::dft(int dir, int len, double *real, double *imag) {
         }
     }
 
-    delete x2;
-    delete y2;
+    delete[] x2;
+    delete[] y2;
 }
 
 void DigitalFiltering::fftshift(double *data, int len)
@@ -300,8 +300,8 @@ QVector<double> DigitalFiltering::fftWithShift(QVector<double> &signal, int resu
         result.append(fabs(signal_vector[i]) / div_factor);
     }
 
-    delete signal_vector;
-    delete imag;
+    delete[] signal_vector;
+    delete[] imag;
 
     return result;
 }


### PR DESCRIPTION
Compiling on macOS gives several warnings of this type:

    ../vesc_tool/digitalfiltering.cpp:140:5: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
        delete x2;
        ^
Mismatching delete operators can lead to undefined behaviour and is better to avoid