### PR TITLE
Fix -Wabsolute-value warnings

### DIFF
--- a/widgets/parameditdouble.cpp
+++ b/widgets/parameditdouble.cpp
@@ -71,8 +71,8 @@ void ParamEditDouble::setConfig(ConfigParams *config)
 
         mParam = *param;
 
-        mMaxVal = fabs(mParam.maxDouble) > fabs(mParam.minDouble) ?
-                    fabs(mParam.maxDouble) : fabsf(mParam.minDouble);
+        mMaxVal = std::abs(mParam.maxDouble) > std::abs(mParam.minDouble) ?
+                    std::abs(mParam.maxDouble) : std::abs(mParam.minDouble);
 
         mDoubleBox->setMaximum(mParam.maxDouble * mParam.editorScale);
         mDoubleBox->setMinimum(mParam.minDouble * mParam.editorScale);


### PR DESCRIPTION
Fixed a warning by using std::abs instead of fabs

    ../vesc_tool/widgets/parameditdouble.cpp:75:46: warning: absolute value function 'fabsf' given an argument of type 'double' but has parameter of type 'float' which may cause truncation of value [-Wabsolute-value]
                    fabs(mParam.maxDouble) : fabsf(mParam.minDouble);
                                             ^

    note: use function 'std::abs' instead
