### PR TITLE
Add support for BTLE connections on macOS

### DIFF
--- a/bleuart.cpp
+++ b/bleuart.cpp
@@ -55,7 +55,17 @@ void BleUart::startConnect(QString addr)
     mUartServiceFound = false;
     mConnectDone = false;
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    // Create BT Controller from unique device UUID stored as addr. Creating
+    // a controller using a devices address is not supported on macOS or iOS.
+    QBluetoothDeviceInfo deviceInfo = QBluetoothDeviceInfo();
+    deviceInfo.setDeviceUuid(QBluetoothUuid(addr));
+    mControl = new QLowEnergyController(deviceInfo);
+
+#else
     mControl = new QLowEnergyController(QBluetoothAddress(addr));
+
+#endif
 
     mControl->setRemoteAddressType(QLowEnergyController::RandomAddress);
 
@@ -122,7 +132,14 @@ void BleUart::addDevice(const QBluetoothDeviceInfo &dev)
     if (dev.coreConfigurations() & QBluetoothDeviceInfo::LowEnergyCoreConfiguration) {
         qDebug() << "BLE scan found device:" << dev.name();
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+        // macOS and iOS do not expose the hardware address of BLTE devices, must use
+        // the OS generated UUID.
+        mDevs.insert(dev.deviceUuid().toString(), dev.name());
+#else
         mDevs.insert(dev.address().toString(), dev.name());
+
+#endif
 
         emit scanDone(mDevs, false);
     }


### PR DESCRIPTION
BTLE support in the VESC Tool on macOS (and iOS) does not currently work. The VESC Tool is able to scan and successfully finds BTLE devices (nrf51822 in this case), but the address displayed is always `00:00:00:00:00:00`. Attempting to connect to this address fails as would be expected.

![image](https://user-images.githubusercontent.com/4476041/41162861-70dcde68-6b7a-11e8-9b1b-8c4c002b7a8e.png)

The cause of this issue is that both macOS and iOS do not provide access to the BT device hardware addresses (apparently a security/privacy issue). This is noted in [the Qt documentation](http://doc.qt.io/qt-5/qbluetoothdeviceinfo.html#deviceUuid). On these platforms an OS generated device UUID must be used instead.

This commit simply uses the address variable to store the device UUID but only on the macOS and iOS platforms, it then uses the UUID to make the connection. Another approach would be to pass around the `QBluetoothDeviceInfo` class, but this would require reworking a bit more code...

These changes as seen on macOS.

![vesc_tool_btle_uuidfix](https://user-images.githubusercontent.com/4476041/41163985-6842875a-6b7d-11e8-8a0f-4a9bacb8cb84.png)

Note: there's probably not a lot of benefit displaying these UUIDs to users. While they will be consistent in any device pairing (same nrf to same laptop), the same nrf will give different UUIDs on different laptops (for example). I guess it does help differentiate between different devices if two had the same name.

The "Set Device Name" still works with this change.

![vesc_tool_btle_uuidfix_setname](https://user-images.githubusercontent.com/4476041/41164048-9669cf8a-6b7d-11e8-9aa6-8a009cc1cee1.png)

As an aside the mobile version is surprising functional on iOS given I believe it has never been tested on this platform.

![image](https://user-images.githubusercontent.com/4476041/41164284-1f09b79c-6b7e-11e8-9c47-97c403a3f4b0.png)
