### PR TITLE
Fix compilation issues in MacOS

### DIFF
--- a/vesc_tool.pro
+++ b/vesc_tool.pro
@@ -63,7 +63,7 @@ release_win {
 release_lin {
     # http://micro.nicholaswilson.me.uk/post/31855915892/rules-of-static-linking-libstdc-libc-libgcc
     # http://insanecoding.blogspot.se/2012/07/creating-portable-linux-binaries.html
-    QMAKE_LFLAGS += -static-libstdc++ -static-libgcc
+    QMAKE_LFLAGS += -static-libstdc++
     DESTDIR = build/lin
     OBJECTS_DIR = build/lin/obj
     MOC_DIR = build/lin/obj


### PR DESCRIPTION
The option `-static-libgcc` is not supported on MacOS.