### PR TITLE
running build_lin deletes all files in ../..

### DIFF
--- a/build_lin
+++ b/build_lin
@@ -1,5 +1,6 @@
 #!/bin/bash
-
+echo "this script is very dangerous and will delete all files in ../.. if you don't have build/lin (which it deletes)"
+exit
 # https://github.com/LairdCP/UwTerminalX/wiki/Compiling-Qt-Statically
 # https://wiki.qt.io/Building_Qt_5_from_Git
 


### PR DESCRIPTION
this script needs attention before it can be distributed, since running it will delete all files in ../.. with unconfirmed rm -rf