### PR TITLE
[fix] missing QDateTime include when HAS_POS is disabled

### DIFF
--- a/vescinterface.h
+++ b/vescinterface.h
@@ -21,6 +21,7 @@
 #define VESCINTERFACE_H
 
 #include <QObject>
+#include <QDateTime>
 #include <QTimer>
 #include <QByteArray>
 #include <QList>


### PR DESCRIPTION
When disabling the `HAS_POS` define, the compiler throws a compilation error about `incomplete type ‘QDateTime’`. This is due to indirect include of `QDateTime` via `QGeoPositionInfoSource`, not included when `HAS_POS` is disabled.