### PR TITLE
Fix for firmwares that do not support compression

### DIFF
--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -2940,6 +2940,11 @@ void VescInterface::fwVersionReceived(int major, int minor, QString hw, QByteArr
         mFwSupportsConfiguration = true;
     }
 
+    if ((fw_connected >= qMakePair(3, 100) && fw_connected <= qMakePair(3, 103)) ||
+        (fw_connected >= qMakePair(23, 34) && fw_connected <= qMakePair(23, 46))) {
+        compCommands.clear();
+    }
+
     mCommands->setLimitedCompatibilityCommands(compCommands);
 
     bool wasReceived = mFwVersionReceived;


### PR DESCRIPTION
There are some 3rd party firmwares that have higher version number, but miss LZO compression (and a lot of other things). This fix makes it possible to use latest VESC Tool for updating such firmwares.