### PR TITLE
Added auto-scan if CAN list un-populated

### DIFF
--- a/digitalfiltering.cpp
+++ b/digitalfiltering.cpp
@@ -21,11 +21,6 @@
 #include <cmath>
 #include <QDebug>
 
-
-#ifndef M_PI
-#define M_PI 3.14159265358979
-#endif
-
 DigitalFiltering::DigitalFiltering()
 {
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -402,6 +402,10 @@ void MainWindow::timerSlot()
         }
     }
 
+    if(mVesc->isPortConnected() && ui->canList->count()==0){
+        on_scanCanButton_clicked();
+    }
+
     // CAN fwd
     if (ui->actionCanFwd->isChecked() != mVesc->commands()->getSendCan()) {
         ui->actionCanFwd->setChecked(mVesc->commands()->getSendCan());
@@ -1357,9 +1361,12 @@ void MainWindow::on_actionTerminalPrintThreads_triggered()
     showPage("VESC Terminal");
 }
 
-void MainWindow::on_actionTerminalDRV8301ResetLatchedFaults_triggered()
+void MainWindow::on_actionTerminalDRVResetLatchedFaults_triggered()
 {
     mVesc->commands()->sendTerminalCmd("drv8301_reset_faults");
+    mVesc->commands()->sendTerminalCmd("drv8323s_reset_faults");
+    mVesc->commands()->sendTerminalCmd("drv8320_reset_faults");
+    mVesc->commands()->sendTerminalCmd("drv8305_reset_faults");
 }
 
 void MainWindow::on_actionCanFwd_toggled(bool arg1)
@@ -1492,9 +1499,12 @@ void MainWindow::on_actionRestoreConfigurationsCAN_triggered()
 
 void MainWindow::on_scanCanButton_clicked()
 {
-    if (mVesc) {
+    if (mVesc->isPortConnected()) {
         ui->scanCanButton->setEnabled(false);
         mVesc->commands()->pingCan();
+    }else{
+        ui->canList->clear();
+        showStatusInfo("Connect to VESC before scanning", false);
     }
 }
 
@@ -1504,10 +1514,10 @@ void MainWindow::pingCanRx(QVector<int> devs, bool isTimeout)
     ui->scanCanButton->setEnabled(true);
 
     ui->canList->clear();
-    QListWidgetItem *item = new QListWidgetItem(QString("VESC LOCAL"));
+    QListWidgetItem *item = new QListWidgetItem(QString("MOTOR ID: LOCAL"));
     ui->canList->addItem(item);
     for (int dev: devs) {
-        item = new QListWidgetItem(QString("VESC %1").arg(dev));
+        item = new QListWidgetItem(QString("MOTOR ID: %1").arg(dev));
         ui->canList->addItem(item);
     }
     ui->canList->setCurrentRow(0);
@@ -1520,7 +1530,7 @@ void MainWindow::on_canList_currentRowChanged(int currentRow)
             mVesc->commands()->setSendCan(false);
             mVesc->commands()->getMcconf();
         } else {
-            int id = ui->canList->currentItem()->text().split(" ")[1].toInt();
+            int id = ui->canList->currentItem()->text().split(" ")[2].toInt();
             if (id >= 0 && id < 255) {
                 mVesc->commands()->setCanSendId(quint32(id));
                 mVesc->commands()->setSendCan(true);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -120,7 +120,7 @@ private slots:
     void on_actionTerminalShowHelp_triggered();
     void on_actionTerminalClear_triggered();
     void on_actionTerminalPrintThreads_triggered();
-    void on_actionTerminalDRV8301ResetLatchedFaults_triggered();
+    void on_actionTerminalDRVResetLatchedFaults_triggered();
     void on_actionCanFwd_toggled(bool arg1);
     void on_actionSafetyInformation_triggered();
     void on_actionWarrantyStatement_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -19,7 +19,7 @@
    <string>VESC Tool</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="res_platinum.qrc">
+   <iconset resource="res_free.qrc">
     <normaloff>:/res/icon.png</normaloff>:/res/icon.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -55,7 +55,7 @@
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="res_platinum.qrc">:/res/logo.png</pixmap>
+           <pixmap resource="res_free.qrc">:/res/logo.png</pixmap>
           </property>
           <property name="scaledContents">
            <bool>true</bool>
@@ -545,7 +545,7 @@
      <x>0</x>
      <y>0</y>
      <width>1054</width>
-     <height>23</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -601,7 +601,7 @@
     <addaction name="actionTerminalPrintFaults"/>
     <addaction name="actionTerminalPrintThreads"/>
     <addaction name="separator"/>
-    <addaction name="actionTerminalDRV8301ResetLatchedFaults"/>
+    <addaction name="actionTerminalDRVResetLatchedFaults"/>
     <addaction name="separator"/>
     <addaction name="actionTerminalClear"/>
    </widget>
@@ -1122,13 +1122,13 @@ p, li { white-space: pre-wrap; }
     <string>VESC Tool Changelog</string>
    </property>
   </action>
-  <action name="actionTerminalDRV8301ResetLatchedFaults">
+  <action name="actionTerminalDRVResetLatchedFaults">
    <property name="icon">
     <iconset resource="res.qrc">
      <normaloff>:/res/icons/Bug-96.png</normaloff>:/res/icons/Bug-96.png</iconset>
    </property>
    <property name="text">
-    <string>DRV8301 Reset Latched Faults</string>
+    <string>DRV Reset Latched Faults</string>
    </property>
   </action>
   <action name="actionVESCProjectForums">
@@ -1275,7 +1275,7 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="res_platinum.qrc"/>
+  <include location="res_free.qrc"/>
   <include location="res.qrc"/>
  </resources>
  <connections/>

--- a/map/osmtile.cpp
+++ b/map/osmtile.cpp
@@ -20,11 +20,6 @@
 #include "osmtile.h"
 #include <cmath>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979
-#endif
-
-
 OsmTile::OsmTile(QPixmap pxm, int zoom, int x, int y) : mPixmap(pxm), mZoom(zoom), mX(x), mY(y)
 {
 

--- a/utility.cpp
+++ b/utility.cpp
@@ -33,11 +33,6 @@
 #include <QNetworkInterface>
 #include <QDirIterator>
 
-
-#ifndef M_PI
-#define M_PI 3.14159265358979
-#endif
-
 #ifdef Q_OS_ANDROID
 #include <QtAndroid>
 #include <QAndroidJniObject>

--- a/vesc_tool.pro
+++ b/vesc_tool.pro
@@ -56,6 +56,9 @@ DEFINES += HAS_POS
     # Serial port available
     DEFINES += HAS_SERIALPORT
 }
+win32: {
+    DEFINES += _USE_MATH_DEFINES
+}
 
 # Options
 #CONFIG += build_original

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -31,10 +31,6 @@
 #include <cmath>
 #include "lzokay/lzokay.hpp"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979
-#endif
-
 #ifdef HAS_SERIALPORT
 #include <QSerialPortInfo>
 #endif


### PR DESCRIPTION
Also changed name to motor ID. Think this will be more clear to new users that they are selecting different motors.  Also throw a warning if scan can clicked when not connected and clear the CAN list.

Off-topic I added the other DRVs to reset latched faults from the menu-bar... kind of a hack to send them all but gets the job done.