### PR TITLE
Add END RPM command to the RPM Sweep Experiment

### DIFF
--- a/pages/pageexperiments.cpp
+++ b/pages/pageexperiments.cpp
@@ -183,81 +183,87 @@ void PageExperiments::timerSlot()
     }
 #endif
 
-    if (mState != EXPERIMENT_OFF) {
-        mVesc->commands()->getValues();
+    if(mState == EXPERIMENT_HOLD){
+        mVesc->commands()->setRpm( ui->rpmEndBox->value() );
+    }else{
+        if (mState != EXPERIMENT_OFF) {
 
-        double from = 0.0;
-        double to = 0.0;
-        double step = 0.0;
-        double stepTime = 0.0;
+            mVesc->commands()->getValues();
 
-        switch (mState) {
-        case EXPERIMENT_DUTY:
-            from = ui->dutyFromBox->value();
-            to = ui->dutyToBox->value();
-            step = ui->dutyStepBox->value();
-            stepTime = ui->dutyStepTimeBox->value();
-            break;
-
-        case EXPERIMENT_CURRENT:
-            from = ui->currentFromBox->value();
-            to = ui->currentToBox->value();
-            step = ui->currentStepBox->value();
-            stepTime = ui->currentStepTimeBox->value();
-            break;
-
-        case EXPERIMENT_RPM:
-            from = ui->rpmFromBox->value();
-            to = ui->rpmToBox->value();
-            step = ui->rpmStepBox->value();
-            stepTime = ui->rpmStepTimeBox->value();
-            break;
-
-        default:
-            break;
-        }
-
-        if (from > to) {
-            step = -step;
-        }
-
-        double elapsedSecs = (double)mExperimentTimer.elapsed() / 1000.0;
-        double totalSteps = (to - from) / step;
-        double totalTime = totalSteps * stepTime;
-        double progress = elapsedSecs / totalTime;
-        double stepNow = floor(progress * totalSteps);
-        double valueNow = from + stepNow * step;
-
-        if (progress >= 1.0) {
-            switch (mState) {
-            case EXPERIMENT_RPM:
-                if(ui->keepRPMcheckBox->isChecked()){
-                    mVesc->commands()->setRpm( ui->rpmEndBox->value() );
-                    break;
-                }
-            default:
-                mVesc->commands()->setCurrent(0);
-                break;
-            }
-            mState = EXPERIMENT_OFF;
-        } else {
-            ui->progressBar->setValue(progress * 100);
+            double from = 0.0;
+            double to = 0.0;
+            double step = 0.0;
+            double stepTime = 0.0;
 
             switch (mState) {
             case EXPERIMENT_DUTY:
-                mVesc->commands()->setDutyCycle(valueNow);
+                from = ui->dutyFromBox->value();
+                to = ui->dutyToBox->value();
+                step = ui->dutyStepBox->value();
+                stepTime = ui->dutyStepTimeBox->value();
                 break;
 
             case EXPERIMENT_CURRENT:
-                mVesc->commands()->setCurrent(valueNow);
+                from = ui->currentFromBox->value();
+                to = ui->currentToBox->value();
+                step = ui->currentStepBox->value();
+                stepTime = ui->currentStepTimeBox->value();
                 break;
 
             case EXPERIMENT_RPM:
-                mVesc->commands()->setRpm(valueNow);
+                from = ui->rpmFromBox->value();
+                to = ui->rpmToBox->value();
+                step = ui->rpmStepBox->value();
+                stepTime = ui->rpmStepTimeBox->value();
                 break;
 
             default:
                 break;
+            }
+
+            if (from > to) {
+                step = -step;
+            }
+
+            double elapsedSecs = (double)mExperimentTimer.elapsed() / 1000.0;
+            double totalSteps = (to - from) / step;
+            double totalTime = totalSteps * stepTime;
+            double progress = elapsedSecs / totalTime;
+            double stepNow = floor(progress * totalSteps);
+            double valueNow = from + stepNow * step;
+
+            if (progress >= 1.0) {
+                switch (mState) {
+                case EXPERIMENT_RPM:
+                    if(ui->keepRPMcheckBox->isChecked()){
+                        mVesc->commands()->setRpm( ui->rpmEndBox->value() );
+                        mState = EXPERIMENT_HOLD;
+                        break;
+                    }
+                default:
+                    mVesc->commands()->setCurrent(0);
+                    mState = EXPERIMENT_OFF;
+                    break;
+                }
+            } else {
+                ui->progressBar->setValue(progress * 100);
+
+                switch (mState) {
+                case EXPERIMENT_DUTY:
+                    mVesc->commands()->setDutyCycle(valueNow);
+                    break;
+
+                case EXPERIMENT_CURRENT:
+                    mVesc->commands()->setCurrent(valueNow);
+                    break;
+
+                case EXPERIMENT_RPM:
+                    mVesc->commands()->setRpm(valueNow);
+                    break;
+
+                default:
+                    break;
+                }
             }
         }
     }

--- a/pages/pageexperiments.cpp
+++ b/pages/pageexperiments.cpp
@@ -229,8 +229,17 @@ void PageExperiments::timerSlot()
         double valueNow = from + stepNow * step;
 
         if (progress >= 1.0) {
+            switch (mState) {
+            case EXPERIMENT_RPM:
+                if(ui->keepRPMcheckBox->isChecked()){
+                    mVesc->commands()->setRpm( ui->rpmEndBox->value() );
+                    break;
+                }
+            default:
+                mVesc->commands()->setCurrent(0);
+                break;
+            }
             mState = EXPERIMENT_OFF;
-            mVesc->commands()->setCurrent(0);
         } else {
             ui->progressBar->setValue(progress * 100);
 

--- a/pages/pageexperiments.h
+++ b/pages/pageexperiments.h
@@ -73,7 +73,8 @@ private:
         EXPERIMENT_OFF = 0,
         EXPERIMENT_DUTY,
         EXPERIMENT_CURRENT,
-        EXPERIMENT_RPM
+        EXPERIMENT_RPM,
+        EXPERIMENT_HOLD
     } experiment_state;
 
     Ui::PageExperiments *ui;

--- a/pages/pageexperiments.ui
+++ b/pages/pageexperiments.ui
@@ -45,101 +45,18 @@
        <property name="spacing">
         <number>3</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Duty Sweep</string>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="leftMargin">
-           <number>3</number>
-          </property>
-          <property name="topMargin">
-           <number>3</number>
-          </property>
-          <property name="rightMargin">
-           <number>3</number>
-          </property>
-          <property name="bottomMargin">
-           <number>3</number>
-          </property>
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QDoubleSpinBox" name="dutyFromBox">
-            <property name="prefix">
-             <string>From: </string>
-            </property>
-            <property name="minimum">
-             <double>-1.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="dutyToBox">
-            <property name="prefix">
-             <string>To: </string>
-            </property>
-            <property name="minimum">
-             <double>-1.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.500000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QDoubleSpinBox" name="dutyStepBox">
-            <property name="prefix">
-             <string>Step: </string>
-            </property>
-            <property name="value">
-             <double>0.020000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="dutyStepTimeBox">
-            <property name="prefix">
-             <string>TS: </string>
-            </property>
-            <property name="suffix">
-             <string> s</string>
-            </property>
-            <property name="maximum">
-             <double>1000.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QPushButton" name="dutyRunButton">
-            <property name="text">
-             <string>Run</string>
-            </property>
-            <property name="icon">
-             <iconset resource="../res.qrc">
-              <normaloff>:/res/icons/Circled Play-96.png</normaloff>:/res/icons/Circled Play-96.png</iconset>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="0" column="1">
         <widget class="QGroupBox" name="groupBox_2">
@@ -240,20 +157,122 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="4" column="0" colspan="2">
+        <widget class="QSpinBox" name="sampleIntervalBox">
+         <property name="suffix">
+          <string> ms</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
+         <property name="prefix">
+          <string>Sample Interval: </string>
          </property>
-        </spacer>
+         <property name="minimum">
+          <number>5</number>
+         </property>
+         <property name="maximum">
+          <number>50000</number>
+         </property>
+         <property name="value">
+          <number>40</number>
+         </property>
+        </widget>
        </item>
-       <item row="1" column="0">
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Duty Sweep</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QDoubleSpinBox" name="dutyFromBox">
+            <property name="prefix">
+             <string>From: </string>
+            </property>
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="dutyToBox">
+            <property name="prefix">
+             <string>To: </string>
+            </property>
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.500000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QDoubleSpinBox" name="dutyStepBox">
+            <property name="prefix">
+             <string>Step: </string>
+            </property>
+            <property name="value">
+             <double>0.020000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="dutyStepTimeBox">
+            <property name="prefix">
+             <string>TS: </string>
+            </property>
+            <property name="suffix">
+             <string> s</string>
+            </property>
+            <property name="maximum">
+             <double>1000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QPushButton" name="dutyRunButton">
+            <property name="text">
+             <string>Run</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../res.qrc">
+              <normaloff>:/res/icons/Circled Play-96.png</normaloff>:/res/icons/Circled Play-96.png</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>RPM Sweep</string>
@@ -274,25 +293,6 @@
           <property name="spacing">
            <number>3</number>
           </property>
-          <item row="0" column="0">
-           <widget class="QDoubleSpinBox" name="rpmFromBox">
-            <property name="prefix">
-             <string>From: </string>
-            </property>
-            <property name="decimals">
-             <number>0</number>
-            </property>
-            <property name="minimum">
-             <double>-500000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>500000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>100.000000000000000</double>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="rpmToBox">
             <property name="prefix">
@@ -334,6 +334,25 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QDoubleSpinBox" name="rpmFromBox">
+            <property name="prefix">
+             <string>From: </string>
+            </property>
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="minimum">
+             <double>-500000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>500000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="rpmStepTimeBox">
             <property name="prefix">
@@ -350,7 +369,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="2" column="0" colspan="3">
            <widget class="QPushButton" name="rpmRunButton">
             <property name="text">
              <string>Run</string>
@@ -361,26 +380,42 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="2">
+           <widget class="QDoubleSpinBox" name="rpmEndBox">
+            <property name="prefix">
+             <string>End: </string>
+            </property>
+            <property name="suffix">
+             <string/>
+            </property>
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="minimum">
+             <double>-500000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>500000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>10000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="keepRPMcheckBox">
+            <property name="text">
+             <string>Keep End RPM</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QSpinBox" name="sampleIntervalBox">
-         <property name="suffix">
-          <string> ms</string>
-         </property>
-         <property name="prefix">
-          <string>Sample Interval: </string>
-         </property>
-         <property name="minimum">
-          <number>5</number>
-         </property>
-         <property name="maximum">
-          <number>50000</number>
-         </property>
-         <property name="value">
-          <number>40</number>
-         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
During our tests with the Dyno we made with two Leaf motors coupled together, driven by 2 Axiom Boards, we found useful and safety important to add a tweak to the RPM sweep experiment that allows to keep a desired END RPM command being sent at the end of the experiment. 

If we do not do that, as the 2nd motor that is coupled together faces that load goes to 0 very fast, and RPMs can jump to a higher RPM that can risk the structure of our dyno. 

![Captura](https://user-images.githubusercontent.com/48726170/81509639-56845a00-92e2-11ea-968c-057c7510236f.JPG)

If you leave the "Keep End RPM" option unchecked,  system will work as before. 

If you check it, at the end of the sweep run, Vesc Tool will start sending RPM commands with the speed selected in the "End" Box.

Hope you find this useful,  and let me know if anything needs to be upgraded. 
