### PR TITLE
Added Speed Input Ramp control variables

### DIFF
--- a/res/config/5.01/parameters_mcconf.xml
+++ b/res/config/5.01/parameters_mcconf.xml
@@ -2317,40 +2317,28 @@ p, li { white-space: pre-wrap; }
             <cDefine>MCCONF_S_PID_ALLOW_BRAKING</cDefine>
             <valInt>1</valInt>
         </s_pid_allow_braking>
-        <s_pid_apply_input_ramp>
-            <longName>Apply Speed Input Ramp</longName>
-            <type>5</type>
-            <transmittable>1</transmittable>
-            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;If set to true, it adds an input ramp to the speed PID loop&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
-            <cDefine>MCCONF_S_PID_APPLY_INPUT_RAMP</cDefine>
-            <valInt>0</valInt>
-        </s_pid_apply_input_ramp>
-        <s_pid_ramp_erpms_ms>
-            <longName>Ramp eRPMs per ms</longName>
+        <s_pid_ramp_erpms_s>
+            <longName>Ramp eRPMs per second</longName>
             <type>1</type>
             <transmittable>1</transmittable>
             <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;This allows to control how fast does the input of the speed command is allowed to increase each milisecond&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
-            <cDefine>MCCONF_S_PID_RAMP_ERPMS_MS</cDefine>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;This allows to control how fast does the input of the speed command is allowed to increase each second. If user does not want to use this ramp, just apply a negative value such as -1.0. Only positive values are considered.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>MCCONF_S_PID_RAMP_ERPMS_S</cDefine>
             <editorDecimalsDouble>2</editorDecimalsDouble>
             <editorScale>1</editorScale>
             <editAsPercentage>0</editAsPercentage>
-            <maxDouble>100</maxDouble>
-            <minDouble>0</minDouble>
+            <maxDouble>100000</maxDouble>
+            <minDouble>-100</minDouble>
             <showDisplay>0</showDisplay>
             <stepDouble>1</stepDouble>
-            <valDouble>1</valDouble>
+            <valDouble>-1</valDouble>
             <vTxDoubleScale>1000</vTxDoubleScale>
             <suffix></suffix>
             <vTx>9</vTx>
-        </s_pid_ramp_erpms_ms>
+        </s_pid_ramp_erpms_s>
         <p_pid_kp>
             <longName>Position PID Kp</longName>
             <type>1</type>
@@ -3306,8 +3294,7 @@ p, li { white-space: pre-wrap; }
         <ser>s_pid_kd_filter</ser>
         <ser>s_pid_min_erpm</ser>
         <ser>s_pid_allow_braking</ser>
-        <ser>s_pid_apply_input_ramp</ser>
-        <ser>s_pid_ramp_erpms_ms</ser>
+        <ser>s_pid_ramp_erpms_s</ser>
         <ser>p_pid_kp</ser>
         <ser>p_pid_ki</ser>
         <ser>p_pid_kd</ser>
@@ -3594,8 +3581,7 @@ p, li { white-space: pre-wrap; }
                     <param>s_pid_kd_filter</param>
                     <param>s_pid_min_erpm</param>
                     <param>s_pid_allow_braking</param>
-                    <param>s_pid_apply_input_ramp</param>
-                    <param>s_pid_ramp_erpms_ms</param>
+                    <param>s_pid_ramp_erpms_s</param>
                     <param>::sep::Position Controller</param>
                     <param>p_pid_kp</param>
                     <param>p_pid_ki</param>

--- a/res/config/5.01/parameters_mcconf.xml
+++ b/res/config/5.01/parameters_mcconf.xml
@@ -2317,6 +2317,40 @@ p, li { white-space: pre-wrap; }
             <cDefine>MCCONF_S_PID_ALLOW_BRAKING</cDefine>
             <valInt>1</valInt>
         </s_pid_allow_braking>
+        <s_pid_apply_input_ramp>
+            <longName>Apply Speed Input Ramp</longName>
+            <type>5</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;If set to true, it adds an input ramp to the speed PID loop&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>MCCONF_S_PID_APPLY_INPUT_RAMP</cDefine>
+            <valInt>0</valInt>
+        </s_pid_apply_input_ramp>
+        <s_pid_ramp_erpms_ms>
+            <longName>Ramp eRPMs per ms</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;This allows to control how fast does the input of the speed command is allowed to increase each milisecond&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>MCCONF_S_PID_RAMP_ERPMS_MS</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>100</maxDouble>
+            <minDouble>0</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>1</stepDouble>
+            <valDouble>1</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix></suffix>
+            <vTx>9</vTx>
+        </s_pid_ramp_erpms_ms>
         <p_pid_kp>
             <longName>Position PID Kp</longName>
             <type>1</type>
@@ -3272,6 +3306,8 @@ p, li { white-space: pre-wrap; }
         <ser>s_pid_kd_filter</ser>
         <ser>s_pid_min_erpm</ser>
         <ser>s_pid_allow_braking</ser>
+        <ser>s_pid_apply_input_ramp</ser>
+        <ser>s_pid_ramp_erpms_ms</ser>
         <ser>p_pid_kp</ser>
         <ser>p_pid_ki</ser>
         <ser>p_pid_kd</ser>
@@ -3558,6 +3594,8 @@ p, li { white-space: pre-wrap; }
                     <param>s_pid_kd_filter</param>
                     <param>s_pid_min_erpm</param>
                     <param>s_pid_allow_braking</param>
+                    <param>s_pid_apply_input_ramp</param>
+                    <param>s_pid_ramp_erpms_ms</param>
                     <param>::sep::Position Controller</param>
                     <param>p_pid_kp</param>
                     <param>p_pid_ki</param>


### PR DESCRIPTION
Added Speed Input Ramp control variables in Speed section in Controllers Page

This works together with this pull request in BLDC repo.

https://github.com/vedderb/bldc/pull/166

This was really useful during our tests, to increase control capability is Speed PID.

Signed-off-by: Maximiliano Cordoba <mcordoba@powerdesigns.ca>