### PR TITLE
Add odometer for mobile (stored in FW emulated EEPROM).

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -464,6 +464,9 @@ void Commands::processPacket(QByteArray data)
         if (mask & (uint32_t(1) << 19)) {
             values.battery_wh = vb.vbPopFrontDouble32(1e3);
         }
+        if (mask & (uint32_t(1) << 20)) {
+            values.odometer = vb.vbPopFrontUint32();
+        }
 
         emit valuesSetupReceived(values, mask);
     } break;
@@ -703,6 +706,16 @@ void Commands::getValues()
     VByteArray vb;
     vb.vbAppendInt8(COMM_GET_VALUES);
     emitData(vb);
+}
+
+void Commands::setOdometer(unsigned odometer_meters)
+{
+    qDebug() << "Set odometer: " << odometer_meters;
+    VByteArray vb;
+    vb.vbAppendInt8(COMM_SET_ODOMETER);
+    vb.vbAppendUint32(odometer_meters);
+    emitData(vb);
+	
 }
 
 void Commands::sendTerminalCmd(QString cmd)

--- a/commands.h
+++ b/commands.h
@@ -56,6 +56,8 @@ public:
 
     Q_INVOKABLE static QString faultToStr(mc_fault_code fault);
 
+    Q_INVOKABLE void setOdometer(unsigned odometer_meters);
+
 signals:
     void dataToSend(QByteArray &data);
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -84,7 +84,9 @@ typedef enum {
     FAULT_CODE_UNBALANCED_CURRENTS,
     FAULT_CODE_RESOLVER_LOT,
     FAULT_CODE_RESOLVER_DOS,
-    FAULT_CODE_RESOLVER_LOS
+    FAULT_CODE_RESOLVER_LOS,
+    FAULT_CODE_FLASH_CORRUPTION_APP_CFG,
+    FAULT_CODE_FLASH_CORRUPTION_MC_CFG
 } mc_fault_code;
 
 typedef enum {
@@ -121,7 +123,7 @@ struct MC_VALUES {
     Q_PROPERTY(double position MEMBER position)
     Q_PROPERTY(mc_fault_code fault_code MEMBER fault_code)
     Q_PROPERTY(int vesc_id MEMBER vesc_id)
-    Q_PROPERTY(QString fault_str MEMBER fault_str)
+    Q_PROPERTY(QString FAULT_str MEMBER fault_str)
     Q_PROPERTY(double vd MEMBER vd)
     Q_PROPERTY(double vq MEMBER vq)
 
@@ -539,6 +541,7 @@ typedef enum {
     COMM_SET_BLE_PIN,
     COMM_SET_CAN_MODE,
     COMM_GET_IMU_CALIBRATION,
+    COMM_GET_MCCONF_TEMP,
     COMM_SET_ODOMETER
 } COMM_PACKET_ID;
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -214,6 +214,7 @@ struct SETUP_VALUES {
     Q_PROPERTY(int num_vescs MEMBER num_vescs)
     Q_PROPERTY(double battery_wh MEMBER battery_wh)
     Q_PROPERTY(QString fault_str MEMBER fault_str)
+    Q_PROPERTY(unsigned odometer MEMBER odometer)
 
 public:
     SETUP_VALUES() {
@@ -237,6 +238,7 @@ public:
         vesc_id = 0;
         num_vescs = 0;
         battery_wh = 0.0;
+        odometer = 0;
     }
 
     bool operator==(const SETUP_VALUES &other) const {
@@ -270,6 +272,7 @@ public:
     int num_vescs;
     double battery_wh;
     QString fault_str;
+    unsigned odometer;
 };
 
 Q_DECLARE_METATYPE(SETUP_VALUES)
@@ -535,7 +538,8 @@ typedef enum {
     COMM_SET_BLE_NAME,
     COMM_SET_BLE_PIN,
     COMM_SET_CAN_MODE,
-    COMM_GET_IMU_CALIBRATION
+    COMM_GET_IMU_CALIBRATION,
+    COMM_SET_ODOMETER
 } COMM_PACKET_ID;
 
 // CAN commands

--- a/mobile/RtDataSetup.qml
+++ b/mobile/RtDataSetup.qml
@@ -31,6 +31,7 @@ Item {
     id: rtData
     property Commands mCommands: VescIf.commands()
     property ConfigParams mMcConf: VescIf.mcConfig()
+    property int odometerValue: 0
     property bool isHorizontal: rtData.width > rtData.height
 
     property int gaugeSize: isHorizontal ? Math.min((height - valMetrics.height * 4) - 30, width / 3.5 - 10) :
@@ -87,7 +88,7 @@ Item {
                 typeText: "Current"
             }
         }
-
+        
         CustomGauge {
             id: speedGauge
             Layout.alignment: Qt.AlignHCenter
@@ -181,6 +182,65 @@ Item {
                 font: valText.font
                 text: valText.text
             }
+                        
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {  
+                   var impFact = VescIf.useImperialUnits() ? 0.621371192 : 1.0
+                   odometerBox.realValue = odometerValue*impFact/1000.0
+                   tripDialog.open() 
+                }
+              
+                Dialog {
+                    id: tripDialog
+                    modal: true
+                    focus: true
+                    width: parent.width - 20
+                    height: Math.min(implicitHeight, parent.height - 60)
+                    closePolicy: Popup.CloseOnEscape
+                    x: 10
+                    y: 50
+                    parent: ApplicationWindow.overlay
+                    standardButtons: Dialog.Ok | Dialog.Cancel
+                    onAccepted: { 
+                        var impFact = VescIf.useImperialUnits() ? 0.621371192 : 1.0
+                        mCommands.setOdometer(Math.round(odometerBox.realValue*1000/impFact)) 
+                    }
+
+                    ColumnLayout {
+                        id: scrollColumn
+                        anchors.fill: parent
+
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            clip: true
+                            contentWidth: parent.width
+                            ColumnLayout {
+                                anchors.fill: parent
+                                spacing: 0
+
+                                Text {
+                                    color: "white"
+                                    text: "Odometer"
+                                    font.bold: true
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.fillWidth: true
+                                    font.pointSize: 12
+                                }
+
+                                DoubleSpinBox {
+                                    id: odometerBox
+                                    decimals: 3
+                                    realFrom: 0.0
+                                    realTo: 999999999.0
+                                    Layout.fillWidth: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -226,22 +286,24 @@ Item {
             powerGauge.value = (values.current_in * values.v_in)
 
             valText.text =
+                    "VESCs  : " + values.num_vescs + "\n" +
                     "mAh Out: " + parseFloat(values.amp_hours * 1000.0).toFixed(1) + "\n" +
-                    "mAh In : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1) + "\n" +
-                    "Wh Out : " + parseFloat(values.watt_hours).toFixed(2) + "\n" +
-                    "Wh In  : " + parseFloat(values.watt_hours_charged).toFixed(2)
+                    "mAh In : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1)
 
+            odometerValue = values.odometer;
+            
             var wh_km = (values.watt_hours - values.watt_hours_charged) / (values.tachometer_abs / 1000.0)
 
-            var l1Txt = useImperial ? "Mi Trip : " : "Km Trip : "
-            var l2Txt = useImperial ? "Wh/Mi   : " : "Wh/Km   : "
-            var l3Txt = useImperial ? "Mi Range: " : "Km Range: "
+            var l1Txt = useImperial ? "mi Trip : " : "km Trip : "
+            var l2Txt = useImperial ? "mi ODO  : " : "km ODO  : "
+            var l3Txt = useImperial ? "Wh/mi   : " : "Wh/km   : "
+            var l4Txt = useImperial ? "mi Range: " : "km Range: "
 
             valText2.text =
                     l1Txt + parseFloat((values.tachometer_abs * impFact) / 1000.0).toFixed(3) + "\n" +
-                    l2Txt + parseFloat(wh_km / impFact).toFixed(1) + "\n" +
-                    l3Txt + parseFloat(values.battery_wh / (wh_km / impFact)).toFixed(2) + "\n" +
-                    "VESCs   : " + values.num_vescs
+                    l2Txt + parseFloat((values.odometer * impFact) / 1000.0).toFixed(odometerBox.decimals) + "\n" +
+                    l3Txt + parseFloat(wh_km / impFact).toFixed(1) + "\n" +
+                    l4Txt + parseFloat(values.battery_wh / (wh_km / impFact)).toFixed(2)
         }
     }
 }


### PR DESCRIPTION
* Tap text area to set value on 2nd real-time screen.
* Remove Wh info to make space.
  Wh info is already shown on 1st real-time screen.
* Capitalization of Km/Mi corrected to km/mi.

[Firmware (bldc) pull request](https://github.com/vedderb/bldc/pull/216#issue-493626557).
![image](https://user-images.githubusercontent.com/5635969/94350347-6d221800-001b-11eb-9712-3934d6e201dc.png)
