### PR TITLE
Lower default Duty Cycle Current Limit Start

### DIFF
--- a/res/config/5.02/parameters_mcconf.xml
+++ b/res/config/5.02/parameters_mcconf.xml
@@ -658,7 +658,7 @@ p, li { white-space: pre-wrap; }
             <minDouble>0</minDouble>
             <showDisplay>1</showDisplay>
             <stepDouble>0.01</stepDouble>
-            <valDouble>1</valDouble>
+            <valDouble>0.85</valDouble>
             <vTxDoubleScale>1e+06</vTxDoubleScale>
             <suffix></suffix>
             <vTx>9</vTx>


### PR DESCRIPTION
This needs to default less than Maximum Duty Cycle which defaults to 95%.

This updates the default Duty Cycle Current Limit Start in the Motor > General > Advanced tab.