### PR TITLE
Lower default Fault Stop Time

### DIFF
--- a/res/config/5.02/parameters_mcconf.xml
+++ b/res/config/5.02/parameters_mcconf.xml
@@ -2579,7 +2579,7 @@ p, li { white-space: pre-wrap; }
             <minInt>-1</minInt>
             <showDisplay>0</showDisplay>
             <stepInt>500</stepInt>
-            <valInt>500</valInt>
+            <valInt>85</valInt>
             <suffix> ms</suffix>
             <vTx>6</vTx>
         </m_fault_stop_time_ms>


### PR DESCRIPTION
The high default of 500ms can easily knock folks off their electric longboards --- and after lots of experience, I feel like sub-100ms values work better.  It could be more risky for some hardware but I feel like it's safer for most humans.  Given the choice between body or ESC I will choose body every time.

I'd like to propose changing this default.

This updates the default Fault Stop Time in the Motor > General > Advanced tab.