### PR TITLE
Add odometer for mobile (stored in FW emulated EEPROM). (again)

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -465,6 +465,9 @@ void Commands::processPacket(QByteArray data)
         if (mask & (uint32_t(1) << 19)) {
             values.battery_wh = vb.vbPopFrontDouble32(1e3);
         }
+        if (mask & (uint32_t(1) << 20)) {
+            values.odometer = vb.vbPopFrontUint32();
+        }
 
         emit valuesSetupReceived(values, mask);
     } break;
@@ -704,6 +707,16 @@ void Commands::getValues()
     VByteArray vb;
     vb.vbAppendInt8(COMM_GET_VALUES);
     emitData(vb);
+}
+
+void Commands::setOdometer(unsigned odometer_meters)
+{
+    qDebug() << "Set odometer: " << odometer_meters;
+    VByteArray vb;
+    vb.vbAppendInt8(COMM_SET_ODOMETER);
+    vb.vbAppendUint32(odometer_meters);
+    emitData(vb);
+	
 }
 
 void Commands::sendTerminalCmd(QString cmd)

--- a/commands.h
+++ b/commands.h
@@ -59,6 +59,8 @@ public:
     Q_INVOKABLE QByteArray bmReadMemWait(uint32_t addr, quint16 size, int timeoutMs = 3000);
     Q_INVOKABLE int bmWriteMemWait(uint32_t addr, QByteArray data, int timeoutMs = 3000);
 
+    Q_INVOKABLE void setOdometer(unsigned odometer_meters);
+
 signals:
     void dataToSend(QByteArray &data);
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -84,7 +84,9 @@ typedef enum {
     FAULT_CODE_UNBALANCED_CURRENTS,
     FAULT_CODE_RESOLVER_LOT,
     FAULT_CODE_RESOLVER_DOS,
-    FAULT_CODE_RESOLVER_LOS
+    FAULT_CODE_RESOLVER_LOS,
+    FAULT_CODE_FLASH_CORRUPTION_APP_CFG,
+    FAULT_CODE_FLASH_CORRUPTION_MC_CFG
 } mc_fault_code;
 
 typedef enum {
@@ -214,6 +216,7 @@ struct SETUP_VALUES {
     Q_PROPERTY(int num_vescs MEMBER num_vescs)
     Q_PROPERTY(double battery_wh MEMBER battery_wh)
     Q_PROPERTY(QString fault_str MEMBER fault_str)
+    Q_PROPERTY(unsigned odometer MEMBER odometer)
 
 public:
     SETUP_VALUES() {
@@ -237,6 +240,7 @@ public:
         vesc_id = 0;
         num_vescs = 0;
         battery_wh = 0.0;
+        odometer = 0;
     }
 
     bool operator==(const SETUP_VALUES &other) const {
@@ -270,6 +274,7 @@ public:
     int num_vescs;
     double battery_wh;
     QString fault_str;
+    unsigned odometer;
 };
 
 Q_DECLARE_METATYPE(SETUP_VALUES)
@@ -537,6 +542,7 @@ typedef enum {
     COMM_SET_CAN_MODE,
     COMM_GET_IMU_CALIBRATION,
     COMM_GET_MCCONF_TEMP,
+    COMM_SET_ODOMETER,
 
     // Custom configuration for hardware
     COMM_GET_CUSTOM_CONFIG_XML,

--- a/mobile/RtDataSetup.qml
+++ b/mobile/RtDataSetup.qml
@@ -31,6 +31,7 @@ Item {
     id: rtData
     property Commands mCommands: VescIf.commands()
     property ConfigParams mMcConf: VescIf.mcConfig()
+    property int odometerValue: 0
     property bool isHorizontal: rtData.width > rtData.height
 
     property int gaugeSize: isHorizontal ? Math.min((height - valMetrics.height * 4) - 30, width / 3.5 - 10) :
@@ -87,7 +88,7 @@ Item {
                 typeText: "Current"
             }
         }
-
+        
         CustomGauge {
             id: speedGauge
             Layout.alignment: Qt.AlignHCenter
@@ -181,6 +182,65 @@ Item {
                 font: valText.font
                 text: valText.text
             }
+                        
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {  
+                   var impFact = VescIf.useImperialUnits() ? 0.621371192 : 1.0
+                   odometerBox.realValue = odometerValue*impFact/1000.0
+                   tripDialog.open() 
+                }
+              
+                Dialog {
+                    id: tripDialog
+                    modal: true
+                    focus: true
+                    width: parent.width - 20
+                    height: Math.min(implicitHeight, parent.height - 60)
+                    closePolicy: Popup.CloseOnEscape
+                    x: 10
+                    y: 50
+                    parent: ApplicationWindow.overlay
+                    standardButtons: Dialog.Ok | Dialog.Cancel
+                    onAccepted: { 
+                        var impFact = VescIf.useImperialUnits() ? 0.621371192 : 1.0
+                        mCommands.setOdometer(Math.round(odometerBox.realValue*1000/impFact)) 
+                    }
+
+                    ColumnLayout {
+                        id: scrollColumn
+                        anchors.fill: parent
+
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            clip: true
+                            contentWidth: parent.width
+                            ColumnLayout {
+                                anchors.fill: parent
+                                spacing: 0
+
+                                Text {
+                                    color: "white"
+                                    text: "Odometer"
+                                    font.bold: true
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.fillWidth: true
+                                    font.pointSize: 12
+                                }
+
+                                DoubleSpinBox {
+                                    id: odometerBox
+                                    decimals: 3
+                                    realFrom: 0.0
+                                    realTo: 999999999.0
+                                    Layout.fillWidth: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -226,22 +286,24 @@ Item {
             powerGauge.value = (values.current_in * values.v_in)
 
             valText.text =
+                    "VESCs  : " + values.num_vescs + "\n" +
                     "mAh Out: " + parseFloat(values.amp_hours * 1000.0).toFixed(1) + "\n" +
-                    "mAh In : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1) + "\n" +
-                    "Wh Out : " + parseFloat(values.watt_hours).toFixed(2) + "\n" +
-                    "Wh In  : " + parseFloat(values.watt_hours_charged).toFixed(2)
+                    "mAh In : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1)
 
+            odometerValue = values.odometer;
+            
             var wh_km = (values.watt_hours - values.watt_hours_charged) / (values.tachometer_abs / 1000.0)
 
-            var l1Txt = useImperial ? "Mi Trip : " : "Km Trip : "
-            var l2Txt = useImperial ? "Wh/Mi   : " : "Wh/Km   : "
-            var l3Txt = useImperial ? "Mi Range: " : "Km Range: "
+            var l1Txt = useImperial ? "mi Trip : " : "km Trip : "
+            var l2Txt = useImperial ? "mi ODO  : " : "km ODO  : "
+            var l3Txt = useImperial ? "Wh/mi   : " : "Wh/km   : "
+            var l4Txt = useImperial ? "mi Range: " : "km Range: "
 
             valText2.text =
                     l1Txt + parseFloat((values.tachometer_abs * impFact) / 1000.0).toFixed(3) + "\n" +
-                    l2Txt + parseFloat(wh_km / impFact).toFixed(1) + "\n" +
-                    l3Txt + parseFloat(values.battery_wh / (wh_km / impFact)).toFixed(2) + "\n" +
-                    "VESCs   : " + values.num_vescs
+                    l2Txt + parseFloat((values.odometer * impFact) / 1000.0).toFixed(odometerBox.decimals) + "\n" +
+                    l3Txt + parseFloat(wh_km / impFact).toFixed(1) + "\n" +
+                    l4Txt + parseFloat(values.battery_wh / (wh_km / impFact)).toFixed(2)
         }
     }
 }


### PR DESCRIPTION
* Tap text area to set value on 2nd real-time screen.
* Remove Wh info to make space.
  Wh info is already shown on 1st real-time screen.
* Capitalization of Km/Mi corrected to km/mi.
[Firmware (bldc) pull request.](https://github.com/vedderb/bldc/pull/218)
![image](https://user-images.githubusercontent.com/5635969/95278727-d590a680-081e-11eb-8063-675280fabb4e.png)
