### PR TITLE
Warn on HW mismatch when uploading FW (Desktop)

### DIFF
--- a/pages/pagefirmware.cpp
+++ b/pages/pagefirmware.cpp
@@ -435,6 +435,21 @@ void PageFirmware::uploadFw(bool allOverCan)
 
         if (reply == QMessageBox::Yes) {
             QByteArray data = file.readAll();
+            if (!isBootloader && !mVesc->fwCheckHwCompatibility(data) ) {
+                QMessageBox msg(this);
+                msg.setText(tr("HW incompatibility detected"));
+                msg.setIcon(QMessageBox::Warning);
+                msg.setInformativeText(tr("This firmware file does not seem compatible with: ") +
+                                       mVesc->getHardwareNow() +
+                                       tr("\nContinuing now is probably a BIG, FOOLISH, and COSTLY mistake.\n") +
+                                       tr("Do you want to upload?"));
+                msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                msg.setDefaultButton(QMessageBox::No);
+                if(msg.exec() == QMessageBox::No) {
+                    return;
+                }
+            }
+
             bool fwRes = mVesc->fwUpload(data, isBootloader, allOverCan);
 
             if (!isBootloader && fwRes) {

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -29,6 +29,7 @@
 #include <QRegularExpression>
 #include <QDateTime>
 #include <QDir>
+#include <QByteArrayMatcher>
 #include <cmath>
 #include "lzokay/lzokay.hpp"
 
@@ -516,6 +517,11 @@ QList<QPair<int, int> > VescInterface::getSupportedFirmwarePairs()
 QString VescInterface::getFirmwareNow()
 {
     return mFwTxt;
+}
+
+QString VescInterface::getHardwareNow()
+{
+    return mHwTxt;
 }
 
 QPair<int, int> VescInterface::getFirmwareNowPair()
@@ -1455,6 +1461,13 @@ bool VescInterface::fwUpload(QByteArray &newFirmware, bool isBootloader, bool fw
     }
 
     return true;
+}
+
+//check HW compatibility by searching for current HW name in new FW
+bool VescInterface::fwCheckHwCompatibility(QByteArray newFirmware)
+{
+    QByteArrayMatcher pattern(mHwTxt.toUtf8());
+    return pattern.indexIn(newFirmware) >= 0;
 }
 
 void VescInterface::fwUploadCancel()

--- a/vescinterface.h
+++ b/vescinterface.h
@@ -74,6 +74,7 @@ public:
     Q_INVOKABLE QStringList getSupportedFirmwares();
     QList<QPair<int, int> > getSupportedFirmwarePairs();
     Q_INVOKABLE QString getFirmwareNow();
+    Q_INVOKABLE QString getHardwareNow();
     QPair<int, int> getFirmwareNowPair();
     Q_INVOKABLE void emitStatusMessage(const QString &msg, bool isGood);
     Q_INVOKABLE void emitMessageDialog(const QString &title, const QString &msg, bool isGood, bool richText = false);
@@ -128,6 +129,7 @@ public:
     bool fwEraseNewApp(bool fwdCan, quint32 fwSize);
     bool fwEraseBootloader(bool fwdCan);
     bool fwUpload(QByteArray &newFirmware, bool isBootloader = false, bool fwdCan = false, bool isLzo = true);
+    bool fwCheckHwCompatibility(QByteArray newFirmware);
     Q_INVOKABLE void fwUploadCancel();
     Q_INVOKABLE double getFwUploadProgress();
     Q_INVOKABLE QString getFwUploadStatus();


### PR DESCRIPTION
FW files contain the HW name for which they were built as a text string.  A hardware mismatch for new vs. currently connected FW is detected by searching the new FW binary for the current HW name.  

This implementation is a bit fragile (binaries are allowed to contain whatever text the developer wants) and currently only for desktop (I think) but it would have saved me some worry.  During development, I had pulled code via git that unbeknownst to me changed HW config.  Loading the resulting binary was a mistake, but fortunately there was no damage.  