### PR TITLE
NTC100k Motor Temperature Sensor support

### DIFF
--- a/res/config/5.02/parameters_mcconf.xml
+++ b/res/config/5.02/parameters_mcconf.xml
@@ -2954,6 +2954,7 @@ p, li { white-space: pre-wrap; }
             <enumNames>NTC 10K at 25°C</enumNames>
             <enumNames>PTC 1K at 100 °C</enumNames>
             <enumNames>KTY83/122</enumNames>
+            <enumNames>NTC 100K at 25°C</enumNames>
         </m_motor_temp_sens_type>
         <m_ptc_motor_coeff>
             <longName>Coefficient for PTC Motor Thermistor</longName>


### PR DESCRIPTION
Support for the 100kOhm version of the NTC thermistor, as used
in some PHUB188 balance vehicle hubs

Signed-off-by: Dado Mista <dadomista@gmail.com>