### PR TITLE
Make negative excursion in RT Data gauges follow the motor configuration

### DIFF
--- a/mobile/RtDataSetup.qml
+++ b/mobile/RtDataSetup.qml
@@ -96,7 +96,7 @@ Item {
             Layout.preferredHeight: gaugeSize
             minimumValue: 0
             maximumValue: 60
-            minAngle: -250
+            minAngle: -180
             maxAngle: 70
             labelStep: maximumValue > 60 ? 20 : 10
             value: 20
@@ -249,7 +249,7 @@ Item {
 
         onValuesSetupReceived: {
             currentGauge.maximumValue = Math.ceil(mMcConf.getParamDouble("l_current_max") / 5) * 5 * values.num_vescs
-            currentGauge.minimumValue = -currentGauge.maximumValue
+            currentGauge.minimumValue = -Math.ceil(-mMcConf.getParamDouble("l_current_min") / 5) * 5 * values.num_vescs
 
             currentGauge.value = values.current_motor
             dutyGauge.value = values.duty_now * 100.0
@@ -267,7 +267,7 @@ Item {
 
             if (Math.abs(speedGauge.maximumValue - speedMaxRound) > 6.0) {
                 speedGauge.maximumValue = speedMaxRound
-                speedGauge.minimumValue = -speedMaxRound
+                speedGauge.minimumValue = 0.0
             }
 
             speedGauge.value = values.speed * 3.6 * impFact
@@ -278,9 +278,14 @@ Item {
                                     mMcConf.getParamDouble("l_watt_max")) * values.num_vescs
             var powerMaxRound = (Math.ceil(powerMax / 1000.0) * 1000.0)
 
+            var powerMin = Math.min(values.v_in * Math.min(-mMcConf.getParamDouble("l_in_current_min"),
+                                                           -mMcConf.getParamDouble("l_current_min")),
+                                    -mMcConf.getParamDouble("l_watt_min")) * values.num_vescs
+            var powerMinRound = -(Math.ceil(powerMin / 1000.0) * 1000.0)
+            
             if (Math.abs(powerGauge.maximumValue - powerMaxRound) > 1.2) {
                 powerGauge.maximumValue = powerMaxRound
-                powerGauge.minimumValue = -powerMaxRound
+                powerGauge.minimumValue = powerMinRound
             }
 
             powerGauge.value = (values.current_in * values.v_in)


### PR DESCRIPTION
This commit will change the look of the second page of the RT data gauges.

**Before:**
![Screenshot_20210302-114833](https://user-images.githubusercontent.com/309472/109673931-41203b00-7b55-11eb-9415-978b0a658224.jpg)
Power, current and speed gauges were forced to be zero-centered

**After**
With this change:
* The gauges will follow the negative phase current set in the motor configuration, allowing for asymmetrical gauges
* Only positive speeds are shown like most vehicle display clusters:
![Screenshot_20210302-120758](https://user-images.githubusercontent.com/309472/109674232-85134000-7b55-11eb-872b-431b3b8df568.jpg)

And in the particular case of clutched mid-drive ebikes that can't do regen braking, it removes the negative current and power for a cleaner look (because brake current is set to 0 Amps):
![Screenshot_20210302-122258](https://user-images.githubusercontent.com/309472/109674577-c99edb80-7b55-11eb-9965-870d34ac2b7a.jpg)

