### PR TITLE
Balance-app: Added reverse stop config options

### DIFF
--- a/res/config/5.03/parameters_appconf.xml
+++ b/res/config/5.03/parameters_appconf.xml
@@ -2041,6 +2041,40 @@ p, li { white-space: pre-wrap; }
             <suffix> ERPM</suffix>
             <vTx>3</vTx>
         </app_balance_conf.fault_adc_half_erpm>
+
+        <app_balance_conf.reverse_stop>
+            <longName>Stop on Reverse</longName>
+            <type>5</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Stop the vehicle when running in reverse. This is a feature allowing beginners to easily stop the vehicle without learning to heal-lift or having to jump off.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>APPCONF_BALANCE_REVERSE_STOP</cDefine>
+            <valInt>0</valInt>
+        </app_balance_conf.reverse_stop>
+        <app_balance_conf.reverse_stop_erpm>
+            <longName>Forward ERPM Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Forward ERPM threshold that must be exceeded before the reverse stop feature is engaged. When first getting on the board users may rock back and forth a bit before starting to ride. Once this ERPM threshold is exceeded then any negative speed will stop the board.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>APPCONF_BALANCE_REVERSE_STOP_ERPM</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>100000</maxInt>
+            <minInt>0</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>10</stepInt>
+            <valInt>1000</valInt>
+            <suffix> ERPM</suffix>
+            <vTx>3</vTx>
+        </app_balance_conf.reverse_stop_erpm>
+
         <app_balance_conf.tiltback_angle>
             <longName>Tiltback Angle</longName>
             <type>1</type>
@@ -3535,6 +3569,8 @@ p, li { white-space: pre-wrap; }
         <ser>app_balance_conf.turntilt_speed</ser>
         <ser>app_balance_conf.turntilt_erpm_boost</ser>
         <ser>app_balance_conf.turntilt_erpm_boost_end</ser>
+        <ser>app_balance_conf.reverse_stop</ser>
+        <ser>app_balance_conf.reverse_stop_erpm</ser>
         <ser>app_pas_conf.ctrl_type</ser>
         <ser>app_pas_conf.sensor_type</ser>
         <ser>app_pas_conf.current_scaling</ser>
@@ -3807,6 +3843,9 @@ p, li { white-space: pre-wrap; }
                     <param>app_balance_conf.fault_delay_switch_half</param>
                     <param>app_balance_conf.fault_delay_switch_full</param>
                     <param>app_balance_conf.fault_adc_half_erpm</param>
+                    <param>::sep::Reverse Stop</param>
+                    <param>app_balance_conf.reverse_stop</param>
+                    <param>app_balance_conf.reverse_stop_erpm</param>
                 </subgroupParams>
             </subgroup>
             <subgroup>


### PR DESCRIPTION
Reverse_Stop enables/disables is (default = disabled)

Reverse_Stop_ERPM sets the forward speed threshold to enable
the feature.

Signed-off-by: Dado Mista <dadomista@gmail.com>