### PR TITLE
Firmware upload improvements / switch to safe app

### DIFF
--- a/pages/pagefirmware.cpp
+++ b/pages/pagefirmware.cpp
@@ -361,6 +361,22 @@ void PageFirmware::uploadFw(bool allOverCan)
                                   tr("The VESC is not connected. Please connect it."));
             return;
         }
+        if (!mVesc->deserializeFailedSinceConnected() && (mVesc->appConfig()->getParamEnum("app_to_use") == 9)) {
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::warning(this,
+                                         tr("Warning"),
+                                         tr("Uploading new firmware while the Balance App is active "
+                                            "can be dangerous. Switch to UART App instead?"),
+                                         QMessageBox::Yes | QMessageBox::No | QMessageBox::Abort, QMessageBox::Yes);
+            if (reply == QMessageBox::Yes) {
+                mVesc->commands()->getAppConf();
+                mVesc->appConfig()->updateParamEnum("app_to_use", 3);
+                mVesc->commands()->setAppConf();
+            }
+            else if (reply == QMessageBox::Abort) {
+                return;
+            }
+        }
 
         QFile file;
 

--- a/pages/pagefirmware.cpp
+++ b/pages/pagefirmware.cpp
@@ -462,8 +462,8 @@ void PageFirmware::uploadFw(bool allOverCan)
             reply = QMessageBox::warning(this,
                                          tr("Warning"),
                                          tr("Uploading new firmware will clear all settings on your VESC "
-                                            "and you have to do the configuration again. Do you want to "
-                                            "continue?"),
+                                            "and you have to do the configuration again or restore it from "
+                                            "a backup. Do you want to continue?"),
                                          QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         } else if ((ui->fwTabWidget->currentIndex() == 0 && ui->hwList->count() > 1) || ui->fwTabWidget->currentIndex() == 1) {
             reply = QMessageBox::warning(this,
@@ -500,9 +500,15 @@ void PageFirmware::uploadFw(bool allOverCan)
             if (!isBootloader && fwRes) {
                 QMessageBox::warning(this,
                                      tr("Warning"),
-                                     tr("The firmware upload is done. You must wait at least "
+                                     tr("The firmware upload is almost done. You must wait at least "
                                         "10 seconds before unplugging power. Otherwise the firmware will get corrupted and your "
-                                        "VESC will become bricked. If that happens you need a SWD programmer to recover it."));
+                                        "VESC will become bricked. If that happens you need a SWD programmer to recover it."
+                                        ));
+                QMessageBox::warning(this,
+                                     tr("Reminder"),
+                                     tr("The configuration on your VESC has been reset to defaults. "
+                                        "Don't forget to reconnect to your VESC and restore its configuration."
+                                        ));
             }
         }
     }


### PR DESCRIPTION
Uploading firmware while the motor is still running is unsafe. When balance app is selected the motor(s) may still be active when brake_current > 0

After losing my Bluetooth ability more than once because I accidentally selected the wrong app manually prior to a firmware upload (apps without UART don't support Bluetooth) - I decided to submit this change.

Now if the active app is Balance we offer to switch to UART prior to the firmware upload.

I also added an additional message after the firmware upload reminding the user that his configuration has been reset to defaults and needs to be manually restored.