### PR TITLE
Mobile RT-Data Screen with Speedometer now also shows temperatures

### DIFF
--- a/mobile/RtDataSetup.qml
+++ b/mobile/RtDataSetup.qml
@@ -293,9 +293,10 @@ Item {
             powerGauge.value = (values.current_in * values.v_in)
 
             valText.text =
-                    "VESCs  : " + values.num_vescs + "\n" +
-                    "mAh Out: " + parseFloat(values.amp_hours * 1000.0).toFixed(1) + "\n" +
-                    "mAh In : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1)
+                    "Temp MOS : " + parseFloat(values.temp_mos).toFixed(2) + " \u00B0C\n" +
+                    "Temp Mot : " + parseFloat(values.temp_motor).toFixed(2) + " \u00B0C\n" +
+                    "mAh Out  : " + parseFloat(values.amp_hours * 1000.0).toFixed(1) + "\n" +
+                    "mAh In   : " + parseFloat(values.amp_hours_charged * 1000.0).toFixed(1)
 
             odometerValue = values.odometer;
             


### PR DESCRIPTION
Rather than displaying a constant value (#VESCs) I propose we show
motor and mosfet temperatures on this screen, so while we monitor
speed and duty cycle we can also keep an eye on temperatures.

Signed-off-by: Dado Mista <dadomista@gmail.com>