### PR TITLE
[Sampled data] Receive new sampled data from the firmware

### DIFF
--- a/pages/pagefoc.cpp
+++ b/pages/pagefoc.cpp
@@ -61,6 +61,7 @@ void PageFoc::reloadParams()
         ui->hallTab->clearParams();
         ui->encoderTab->clearParams();
         ui->hfiTab->clearParams();
+        ui->prbsTab->clearParams();
         ui->filterTab->clearParams();
         ui->offsetTab->clearParams();
         ui->fwTab->clearParams();
@@ -72,6 +73,7 @@ void PageFoc::reloadParams()
         ui->encoderTab->addParamSubgroup(mVesc->mcConfig(), "foc", "encoder");
         ui->hfiTab->addParamSubgroup(mVesc->mcConfig(), "foc", "hfi");
         ui->vssTab->addParamSubgroup(mVesc->mcConfig(), "foc", "vss");
+        ui->prbsTab->addParamSubgroup(mVesc->mcConfig(), "foc", "prbs");
         ui->filterTab->addParamSubgroup(mVesc->mcConfig(), "foc", "filters");
         ui->offsetTab->addParamSubgroup(mVesc->mcConfig(), "foc", "offsets");
         ui->fwTab->addParamSubgroup(mVesc->mcConfig(), "foc", "field weakening");

--- a/pages/pagefoc.ui
+++ b/pages/pagefoc.ui
@@ -150,6 +150,16 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_prbs">
+      <attribute name="title">
+       <string>PRBS</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_prbs">
+       <item>
+        <widget class="ParamTable" name="prbsTab"/>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tab_8">
       <attribute name="title">
        <string>Filters</string>

--- a/pages/pagesampleddata.cpp
+++ b/pages/pagesampleddata.cpp
@@ -502,6 +502,7 @@ void PageSampledData::samplesReceived(QByteArray bytes)
     tmpVZeroVector.append(vb.vbPopFrontDouble32Auto());
     tmpCurrTotVector.append(vb.vbPopFrontDouble32Auto());
     tmpFSwVector.append(vb.vbPopFrontDouble32Auto());
+    tmpFrfDVector.append(vb.vbPopFrontDouble32Auto());
     tmpStatusArray.append(vb.vbPopFrontInt8());
     tmpPhaseArray.append(vb.vbPopFrontInt8());
 
@@ -517,6 +518,7 @@ void PageSampledData::samplesReceived(QByteArray bytes)
         vZeroVector = tmpVZeroVector;
         currTotVector = tmpCurrTotVector;
         fSwVector = tmpFSwVector;
+        frfDVector = tmpFrfDVector;
         statusArray = tmpStatusArray;
         phaseArray = tmpPhaseArray;
 
@@ -648,6 +650,7 @@ void PageSampledData::clearBuffers()
     tmpVZeroVector.clear();
     tmpCurrTotVector.clear();
     tmpFSwVector.clear();
+    tmpFrfDVector.clear();
     tmpStatusArray.clear();
     tmpPhaseArray.clear();
 }
@@ -712,7 +715,7 @@ void PageSampledData::on_saveDataButton_clicked()
             prev_t += 1.0 / fSwVector[i];
         }
 
-        stream << "T;I1;I2;I3;V1;V2;V3;I_tot;V_zero;Phase\n";
+        stream << "T;I1;I2;I3;V1;V2;V3;I_tot;V_zero;FRF_d;Phase;PRBS\n";
 
         for (int i = 0;i < curr1Vector.size();i++) {
             stream << timeVec.at(i) << ";";
@@ -724,7 +727,9 @@ void PageSampledData::on_saveDataButton_clicked()
             stream << ph3Vector.at(i) << ";";
             stream << currTotVector.at(i) << ";";
             stream << vZeroVector.at(i) << ";";
+            stream << frfDVector.at(i) << ";";
             stream << (double)((quint8)phaseArray.at(i)) / 250.0 * 360.0 << ";";
+            stream << ((quint8)statusArray.at(i) >> 7) << ";";
 
             if (i < (curr1Vector.size() - 1)) {
                 stream << "\n";

--- a/pages/pagesampleddata.cpp
+++ b/pages/pagesampleddata.cpp
@@ -715,7 +715,7 @@ void PageSampledData::on_saveDataButton_clicked()
             prev_t += 1.0 / fSwVector[i];
         }
 
-        stream << "T;I1;I2;I3;V1;V2;V3;I_tot;V_zero;FRF_d;Phase;PRBS\n";
+        stream << "T;I1;I2;I3;V1;V2;V3;I_tot;V_zero;FRF_d;Phase;PRBS;\n";
 
         for (int i = 0;i < curr1Vector.size();i++) {
             stream << timeVec.at(i) << ";";

--- a/pages/pagesampleddata.cpp
+++ b/pages/pagesampleddata.cpp
@@ -502,7 +502,7 @@ void PageSampledData::samplesReceived(QByteArray bytes)
     tmpVZeroVector.append(vb.vbPopFrontDouble32Auto());
     tmpCurrTotVector.append(vb.vbPopFrontDouble32Auto());
     tmpFSwVector.append(vb.vbPopFrontDouble32Auto());
-    tmpFrfDVector.append(vb.vbPopFrontDouble32Auto());
+    tmpFrfVector.append(vb.vbPopFrontDouble32Auto());
     tmpStatusArray.append(vb.vbPopFrontInt8());
     tmpPhaseArray.append(vb.vbPopFrontInt8());
 
@@ -518,7 +518,7 @@ void PageSampledData::samplesReceived(QByteArray bytes)
         vZeroVector = tmpVZeroVector;
         currTotVector = tmpCurrTotVector;
         fSwVector = tmpFSwVector;
-        frfDVector = tmpFrfDVector;
+        frfVector = tmpFrfVector;
         statusArray = tmpStatusArray;
         phaseArray = tmpPhaseArray;
 
@@ -650,7 +650,7 @@ void PageSampledData::clearBuffers()
     tmpVZeroVector.clear();
     tmpCurrTotVector.clear();
     tmpFSwVector.clear();
-    tmpFrfDVector.clear();
+    tmpFrfVector.clear();
     tmpStatusArray.clear();
     tmpPhaseArray.clear();
 }
@@ -727,7 +727,7 @@ void PageSampledData::on_saveDataButton_clicked()
             stream << ph3Vector.at(i) << ";";
             stream << currTotVector.at(i) << ";";
             stream << vZeroVector.at(i) << ";";
-            stream << frfDVector.at(i) << ";";
+            stream << frfVector.at(i) << ";";
             stream << (double)((quint8)phaseArray.at(i)) / 250.0 * 360.0 << ";";
             stream << ((quint8)statusArray.at(i) >> 7) << ";";
 

--- a/pages/pagesampleddata.h
+++ b/pages/pagesampleddata.h
@@ -75,7 +75,7 @@ private:
     QVector<double> vZeroVector;
     QVector<double> currTotVector;
     QVector<double> fSwVector;
-    QVector<double> frfDVector;
+    QVector<double> frfVector;
     QByteArray statusArray;
     QByteArray phaseArray;
 
@@ -87,7 +87,7 @@ private:
     QVector<double> tmpVZeroVector;
     QVector<double> tmpCurrTotVector;
     QVector<double> tmpFSwVector;
-    QVector<double> tmpFrfDVector;
+    QVector<double> tmpFrfVector;
     QByteArray tmpStatusArray;
     QByteArray tmpPhaseArray;
 

--- a/pages/pagesampleddata.h
+++ b/pages/pagesampleddata.h
@@ -75,6 +75,7 @@ private:
     QVector<double> vZeroVector;
     QVector<double> currTotVector;
     QVector<double> fSwVector;
+    QVector<double> frfDVector;
     QByteArray statusArray;
     QByteArray phaseArray;
 
@@ -86,6 +87,7 @@ private:
     QVector<double> tmpVZeroVector;
     QVector<double> tmpCurrTotVector;
     QVector<double> tmpFSwVector;
+    QVector<double> tmpFrfDVector;
     QByteArray tmpStatusArray;
     QByteArray tmpPhaseArray;
 

--- a/pages/pagesampleddata.ui
+++ b/pages/pagesampleddata.ui
@@ -683,7 +683,7 @@
         <string>Samp: </string>
        </property>
        <property name="maximum">
-        <number>2000</number>
+        <number>2048</number>
        </property>
        <property name="singleStep">
         <number>100</number>

--- a/res/config/5.03/parameters_mcconf.xml
+++ b/res/config/5.03/parameters_mcconf.xml
@@ -2202,6 +2202,66 @@ p, li { white-space: pre-wrap; }
             <enumNames>16</enumNames>
             <enumNames>32</enumNames>
         </foc_hfi_samples>
+
+        <foc_prbs_voltage>
+            <longName>Perturbation Voltage</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>ZAAAAP</description>
+            <cDefine>MCCONF_FOC_PRBS_VOLTAGE</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>700</maxDouble>
+            <minDouble>0</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>1</stepDouble>
+            <valDouble>3</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix> V</suffix>
+            <vTx>9</vTx>
+        </foc_prbs_voltage>
+        <foc_prbs_current>
+            <longName>Perturbation Current</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>ZAAAAP</description>
+            <cDefine>MCCONF_FOC_PRBS_CURRENT</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>700</maxDouble>
+            <minDouble>0</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>1</stepDouble>
+            <valDouble>1</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix> A</suffix>
+            <vTx>9</vTx>
+        </foc_prbs_current>
+        <foc_prbs_mode>
+            <longName>PRBS Mode</longName>
+            <type>4</type>
+            <transmittable>1</transmittable>
+            <description></description>
+            <cDefine>MCCONF_FOC_PRBS_MODE</cDefine>
+            <valInt>0</valInt>
+            <enumNames>Disabled</enumNames>
+            <enumNames>Inject on I</enumNames>
+            <enumNames>Inject on V</enumNames>
+        </foc_prbs_mode>
+        <foc_prbs_channel>
+            <longName>PRBS Channel</longName>
+            <type>4</type>
+            <transmittable>1</transmittable>
+            <description></description>
+            <cDefine>MCCONF_FOC_PRBS_CHANNEL</cDefine>
+            <valInt>0</valInt>
+            <enumNames>D</enumNames>
+            <enumNames>Q</enumNames>
+            <enumNames>D and Q</enumNames>
+        </foc_prbs_channel>
+
         <foc_offsets_cal_on_boot>
             <longName>Run calibration at boot</longName>
             <type>5</type>
@@ -4008,6 +4068,10 @@ p, li { white-space: pre-wrap; }
         <ser>foc_hfi_start_samples</ser>
         <ser>foc_hfi_obs_ovr_sec</ser>
         <ser>foc_hfi_samples</ser>
+        <ser>foc_prbs_voltage</ser>
+        <ser>foc_prbs_current</ser>
+        <ser>foc_prbs_channel</ser>
+        <ser>foc_prbs_mode</ser>
         <ser>foc_offsets_cal_on_boot</ser>
         <ser>foc_offsets_current__0</ser>
         <ser>foc_offsets_current__1</ser>
@@ -4314,6 +4378,15 @@ p, li { white-space: pre-wrap; }
                     <param>foc_hfi_voltage_start</param>
                     <param>foc_hfi_start_samples</param>
                     <param>foc_openloop_rpm</param>
+                </subgroupParams>
+            </subgroup>
+            <subgroup>
+                <subgroupName>PRBS</subgroupName>
+                <subgroupParams>
+                    <param>foc_prbs_voltage</param>
+                    <param>foc_prbs_current</param>
+                    <param>foc_prbs_channel</param>
+                    <param>foc_prbs_mode</param>
                 </subgroupParams>
             </subgroup>
             <subgroup>


### PR DESCRIPTION
This supports the FRF effort, described at https://vesc-project.com/node/3257

We need to add a way in the UI to configure the FRF feature. Currently it hijacks HFI's parameters. Fine for testing, but obviously this won't work for production.