### PR TITLE
Increase max IMU rate

### DIFF
--- a/res/config/5.03/parameters_appconf.xml
+++ b/res/config/5.03/parameters_appconf.xml
@@ -1861,7 +1861,7 @@ p, li { white-space: pre-wrap; }
             <cDefine>APPCONF_BALANCE_HERTZ</cDefine>
             <editorScale>1</editorScale>
             <editAsPercentage>0</editAsPercentage>
-            <maxInt>4000</maxInt>
+            <maxInt>10000</maxInt>
             <minInt>50</minInt>
             <showDisplay>0</showDisplay>
             <stepInt>100</stepInt>
@@ -3407,7 +3407,7 @@ p, li { white-space: pre-wrap; }
             <cDefine>APPCONF_IMU_SAMPLE_RATE_HZ</cDefine>
             <editorScale>1</editorScale>
             <editAsPercentage>0</editAsPercentage>
-            <maxInt>1000</maxInt>
+            <maxInt>10000</maxInt>
             <minInt>1</minInt>
             <showDisplay>0</showDisplay>
             <stepInt>10</stepInt>


### PR DESCRIPTION
Small PR to increase the max allowed IMU update rate. I've found I can get a slight performance gain with a higher rate. Some of the supported IMUs have output data rates up to 8khz so I figured I'd set the max to 10khz.