### PR TITLE
[Info.plist] Correct typo

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
         <key>CFBundleDisplayName</key>
-        <string>$(Vesc Tool)</string>
+        <string>${Vesc Tool}>/string>
         <key>CFBundleExecutable</key>
-        <string>$(EXECUTABLE_NAME)</string>
+        <string>${EXECUTABLE_NAME}>/string>
         <key>CFBundleGetInfoString</key>
         <string>Created by Qt/QMake</string>
         <key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>
-        <string>$(PRODUCT_NAME)</string>
+        <string>${PRODUCT_NAME}>/string>
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>
@@ -37,7 +37,7 @@
         <key>NSBluetoothAlwaysUsageDescription</key>
         <string>Need access to connect to VESC</string>
         <key>NSBluetoothPeripheralUsageDescription</key>
-        <string>$(PRODUCT_NAME) searches Bluetooth LE Devices (WaiterLock, Barcode Scanner, eGK)</string>
+        <string>${PRODUCT_NAME} searches Bluetooth LE Devices (WaiterLock, Barcode Scanner, eGK)</string>
         <key>NSDocumentsFolderUsageDescription</key>
         <string>Saves log files here</string>
         <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
@@ -47,7 +47,7 @@
         <key>NSLocationWhenInUseUsageDescription</key>
         <string>Used for Ride Tracking</string>
         <key>NSPhotoLibraryUsageDescription</key>
-        <string>$(PRODUCT_NAME) uses photos</string>
+        <string>${PRODUCT_NAME} uses photos</string>
         <key>NSSupportsAutomaticGraphicsSwitching</key>
         <true/>
         <key>UIBackgroundModes</key>


### PR DESCRIPTION
Qt looks for ${FOO_BAR}, not $(FOO_BAR). 

C.f. https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-info-plist

Note: I cannot build this for iOS, but the fix is included as according to the docs it requires the same `{}` structure. Before merge, could someone please check that this doesn't break iOS?