### PR TITLE
Use α instead of ω to represent eRPM/s

### DIFF
--- a/widgets/detectfoc.ui
+++ b/widgets/detectfoc.ui
@@ -501,7 +501,7 @@
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ERPM/sec to ramp up the motor in openloop mode with.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="prefix">
-         <string>ω: </string>
+         <string>α: </string>
         </property>
         <property name="suffix">
          <string> ERPM/s</string>


### PR DESCRIPTION
eRPM/s is rotation/(min-s), which is acceleration (although in a trivially confusing min-s instead of sec).

## Before
![unknown (2)](https://user-images.githubusercontent.com/1118185/147150869-85abcb8c-0b93-4d60-a2af-5b16d2808440.png)

## After
<img width="985" alt="Screen Shot 2021-12-22 at 15 23 38" src="https://user-images.githubusercontent.com/1118185/147151050-317be1b4-005f-4f2d-8bb8-6412c2558a25.png">
