### PR TITLE
Scripting dirty marker

### DIFF
--- a/pages/pagescripting.cpp
+++ b/pages/pagescripting.cpp
@@ -108,8 +108,8 @@ PageScripting::PageScripting(QWidget *parent) :
             if (f.exists()) {
                 QFile file(path);
                 if (file.open(QIODevice::ReadOnly)) {
-                    if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-                        ui->mainEdit->editor()->setPlainText(file.readAll());
+                    if (ui->mainEdit->codeEditor()->toPlainText().isEmpty()) {
+                        ui->mainEdit->codeEditor()->setPlainText(file.readAll());
                         ui->mainEdit->setFileNow(path);
                     } else {
                         createEditorTab(path, file.readAll());
@@ -262,8 +262,8 @@ void PageScripting::on_openRecentButton_clicked()
             return;
         }
 
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(file.readAll());
+        if (ui->mainEdit->codeEditor()->toPlainText().isEmpty()) {
+            ui->mainEdit->codeEditor()->setPlainText(file.readAll());
             ui->mainEdit->setFileNow(fileName);
         } else {
             createEditorTab(fileName, file.readAll());
@@ -389,16 +389,16 @@ void PageScripting::updateRecentList()
 
 void PageScripting::makeEditorConnections(QmlEditor *editor)
 {
-    connect(editor->editor(), &QCodeEditor::runEmbeddedTriggered, [this]() {
+    connect(editor->codeEditor(), &QCodeEditor::runEmbeddedTriggered, [this]() {
         on_runButton_clicked();
     });
-    connect(editor->editor(), &QCodeEditor::runWindowTriggered, [this]() {
+    connect(editor->codeEditor(), &QCodeEditor::runWindowTriggered, [this]() {
         on_runWindowButton_clicked();
     });
-    connect(editor->editor(), &QCodeEditor::stopTriggered, [this]() {
+    connect(editor->codeEditor(), &QCodeEditor::stopTriggered, [this]() {
         on_stopButton_clicked();
     });
-    connect(editor->editor(), &QCodeEditor::clearConsoleTriggered, [this]() {
+    connect(editor->codeEditor(), &QCodeEditor::clearConsoleTriggered, [this]() {
         ui->debugEdit->clear();
     });
     connect(editor, &QmlEditor::fileOpened, [this](QString fileName) {
@@ -441,7 +441,7 @@ void PageScripting::createEditorTab(QString fileName, QString content)
     });
 
     editor->setFileNow(fileName);
-    editor->editor()->setPlainText(content);
+    editor->codeEditor()->setPlainText(content);
     QString theme = Utility::getThemePath();
 
     QPushButton *closeButton = new QPushButton();
@@ -456,7 +456,7 @@ void PageScripting::createEditorTab(QString fileName, QString content)
 
 QString PageScripting::qmlToRun(bool importDir)
 {
-    QString res = ui->mainEdit->editor()->toPlainText();
+    QString res = ui->mainEdit->codeEditor()->toPlainText();
     res.prepend("import \"qrc:/mobile\";");
     res.prepend("import Vedder.vesc.vescinterface 1.0;");
 
@@ -645,8 +645,8 @@ void PageScripting::on_exportCArrayAppButton_clicked()
 void PageScripting::on_openQmluiHwButton_clicked()
 {
     if (mVesc && mVesc->isPortConnected() && mVesc->qmlHwLoaded()) {
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(mVesc->qmlHw());
+        if (ui->mainEdit->codeEditor()->toPlainText().isEmpty()) {
+            ui->mainEdit->codeEditor()->setPlainText(mVesc->qmlHw());
             ui->fileTabs->setTabText(ui->fileTabs->indexOf(ui->mainEdit), "VESC Hw");
         } else {
             createEditorTab("VESC Hw", mVesc->qmlHw());
@@ -660,8 +660,8 @@ void PageScripting::on_openQmluiHwButton_clicked()
 void PageScripting::on_openQmluiAppButton_clicked()
 {
     if (mVesc && mVesc->isPortConnected() && mVesc->qmlAppLoaded()) {
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(mVesc->qmlApp());
+        if (ui->mainEdit->codeEditor()->toPlainText().isEmpty()) {
+            ui->mainEdit->codeEditor()->setPlainText(mVesc->qmlApp());
             ui->fileTabs->setTabText(ui->fileTabs->indexOf(ui->mainEdit), "VESC App");
         } else {
             createEditorTab("VESC App", mVesc->qmlApp());

--- a/pages/pagescripting.cpp
+++ b/pages/pagescripting.cpp
@@ -248,7 +248,7 @@ void PageScripting::on_fullscreenButton_clicked()
     mQmlUi.emitToggleFullscreen();
 }
 
-void PageScripting::on_openRecentButton_clicked()
+void PageScripting::openRecentList()
 {
     auto *item = ui->recentList->currentItem();
 
@@ -275,32 +275,16 @@ void PageScripting::on_openRecentButton_clicked()
                               "Please select a file.");
     }
 }
+
+void PageScripting::on_openRecentButton_clicked()
+{
+   openRecentList();
+}
+
+// Recent add list
 void PageScripting::on_recentList_doubleClicked()
 {
-    auto *item = ui->recentList->currentItem();
-
-    if (item) {
-        QString fileName = item->text();
-        QFile file(fileName);
-
-        if (!file.open(QIODevice::ReadOnly)) {
-            QMessageBox::critical(this, "Open QML File",
-                                  "Could not open\n " + fileName + " for reading");
-            return;
-        }
-
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(file.readAll());
-            ui->mainEdit->setFileNow(fileName);
-        } else {
-            createEditorTab(fileName, file.readAll());
-        }
-
-        file.close();
-    } else {
-        QMessageBox::critical(this, "Open Recent",
-                              "Please select a file.");
-    }
+   openRecentList();
 }
 
 void PageScripting::on_removeSelectedButton_clicked()
@@ -325,9 +309,11 @@ void PageScripting::on_clearRecentButton_clicked()
     }
 }
 
-void PageScripting::on_openExampleButton_clicked()
+
+
+void PageScripting::openExample()
 {
-    auto *item = ui->exampleList->currentItem();
+    QListWidgetItem *item = ui->exampleList->currentItem();
 
     if (item) {
         QFile file(item->data(Qt::UserRole).toString());
@@ -338,9 +324,11 @@ void PageScripting::on_openExampleButton_clicked()
             return;
         }
 
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(file.readAll());
+        if (ui->mainEdit->codeEditor()->toPlainText().isEmpty()) {
+            ui->mainEdit->codeEditor()->setPlainText(file.readAll());
             ui->mainEdit->setFileNow("");
+
+            setEditorClean(ui->mainEdit);
         } else {
             createEditorTab("", file.readAll());
         }
@@ -352,31 +340,13 @@ void PageScripting::on_openExampleButton_clicked()
     }
 }
 
+void PageScripting::on_openExampleButton_clicked()
+{
+    openExample();
+}
 void PageScripting::on_exampleList_doubleClicked()
 {
-    auto *item = ui->exampleList->currentItem();
-
-    if (item) {
-        QFile file(item->data(Qt::UserRole).toString());
-
-        if (!file.open(QIODevice::ReadOnly)) {
-            QMessageBox::critical(this, "Open QML File",
-                                  "Could not open example for reading");
-            return;
-        }
-
-        if (ui->mainEdit->editor()->toPlainText().isEmpty()) {
-            ui->mainEdit->editor()->setPlainText(file.readAll());
-            ui->mainEdit->setFileNow("");
-        } else {
-            createEditorTab("", file.readAll());
-        }
-
-        file.close();
-    } else {
-        QMessageBox::critical(this, "Open Example",
-                              "Please select one example.");
-    }
+    openExample();
 }
 
 void PageScripting::updateRecentList()

--- a/pages/pagescripting.cpp
+++ b/pages/pagescripting.cpp
@@ -359,6 +359,9 @@ void PageScripting::updateRecentList()
 
 void PageScripting::makeEditorConnections(QmlEditor *editor)
 {
+    connect(editor->codeEditor(), &QCodeEditor::textChanged, [editor, this]() {
+       setEditorDirty(editor);
+    });
     connect(editor->codeEditor(), &QCodeEditor::runEmbeddedTriggered, [this]() {
         on_runButton_clicked();
     });
@@ -377,7 +380,7 @@ void PageScripting::makeEditorConnections(QmlEditor *editor)
             updateRecentList();
         }
     });
-    connect(editor, &QmlEditor::fileSaved, [this](QString fileName) {
+    connect(editor, &QmlEditor::fileSaved, [editor, this](QString fileName) {
         if (mVesc) {
             mVesc->emitStatusMessage("Saved " + fileName, true);
         }
@@ -386,6 +389,8 @@ void PageScripting::makeEditorConnections(QmlEditor *editor)
             mRecentFiles.append(fileName);
             updateRecentList();
         }
+
+        setEditorClean(editor);
     });
 }
 
@@ -422,6 +427,9 @@ void PageScripting::createEditorTab(QString fileName, QString content)
     connect(closeButton, &QPushButton::clicked, [this, editor]() {
         ui->fileTabs->removeTab(ui->fileTabs->indexOf(editor));
     });
+
+    // Do this at the end to make sure to account for the changes from loading the initial text
+    setEditorClean(editor);
 }
 
 /**

--- a/pages/pagescripting.cpp
+++ b/pages/pagescripting.cpp
@@ -454,6 +454,54 @@ void PageScripting::createEditorTab(QString fileName, QString content)
     });
 }
 
+/**
+ * @brief PageScripting::setEditorDirtySet the editor as dirty, i.e. having text modifications
+ * @param qmlEditor
+ */
+void PageScripting::setEditorDirty(QmlEditor *qmlEditor)
+{
+    // Check if the editor is not already dirty
+    if (qmlEditor->isDirty == false) {
+        // Set editor as dirty
+        qmlEditor->isDirty = true;
+
+        // Get editor index
+        int tabIdx = ui->fileTabs->indexOf(qmlEditor);
+
+        // Append a `*` to signify a dirty editor
+        QString tabText = ui->fileTabs->tabText(tabIdx);
+        ui->fileTabs->setTabText(tabIdx, tabText + "*");
+    }
+}
+
+
+/**
+ * @brief PageScripting::setEditorClean Set the editor as clean, i.e. having no text modifications
+ * @param qmlEditor
+ */
+void PageScripting::setEditorClean(QmlEditor *qmlEditor)
+{
+    // Check if the editor is not already clean
+    if (qmlEditor->isDirty == true) {
+        // Set editor as clean
+        qmlEditor->isDirty = false;
+
+        // Get editor index
+        int tabIdx = ui->fileTabs->indexOf(qmlEditor);
+
+        // Get the tab's label
+        QString tabText = ui->fileTabs->tabText(tabIdx);
+
+        // Check if the final character is a `*`, which indicated it was a dirty file
+        if (tabText.back() == "*") {
+            // Remove the terminal `*`
+            tabText.chop(1);
+            ui->fileTabs->setTabText(tabIdx, tabText);
+        }
+    }
+}
+
+
 QString PageScripting::qmlToRun(bool importDir)
 {
     QString res = ui->mainEdit->codeEditor()->toPlainText();

--- a/pages/pagescripting.h
+++ b/pages/pagescripting.h
@@ -86,6 +86,8 @@ private:
     QString qmlToRun(bool importDir = true);
     bool exportCArray(QString name);
     bool eraseQml();
+    void openExample();
+    void openRecentList();
 
 };
 

--- a/pages/pagescripting.h
+++ b/pages/pagescripting.h
@@ -81,6 +81,7 @@ private:
     void updateRecentList();
     void makeEditorConnections(QmlEditor *editor);
     void createEditorTab(QString fileName, QString content);
+    void removeEditor(QmlEditor *qmlEditor);
     void setEditorDirty(QmlEditor * qmlEditor);
     void setEditorClean(QmlEditor * qmlEditor);
     QString qmlToRun(bool importDir = true);

--- a/pages/pagescripting.h
+++ b/pages/pagescripting.h
@@ -81,6 +81,8 @@ private:
     void updateRecentList();
     void makeEditorConnections(QmlEditor *editor);
     void createEditorTab(QString fileName, QString content);
+    void setEditorDirty(QmlEditor * qmlEditor);
+    void setEditorClean(QmlEditor * qmlEditor);
     QString qmlToRun(bool importDir = true);
     bool exportCArray(QString name);
     bool eraseQml();

--- a/widgets/qmleditor.cpp
+++ b/widgets/qmleditor.cpp
@@ -43,7 +43,7 @@ QmlEditor::~QmlEditor()
     delete ui;
 }
 
-QCodeEditor *QmlEditor::editor()
+QCodeEditor *QmlEditor::codeEditor()
 {
     return ui->qmlEdit;
 }

--- a/widgets/qmleditor.h
+++ b/widgets/qmleditor.h
@@ -16,7 +16,7 @@ public:
     explicit QmlEditor(QWidget *parent = nullptr);
     ~QmlEditor();
 
-    QCodeEditor *editor();
+    QCodeEditor *codeEditor();
     QString fileNow();
     void setFileNow(QString fileName);
 

--- a/widgets/qmleditor.h
+++ b/widgets/qmleditor.h
@@ -20,6 +20,8 @@ public:
     QString fileNow();
     void setFileNow(QString fileName);
 
+    bool isDirty = false;
+
 protected:
     void keyPressEvent(QKeyEvent *event);
 


### PR DESCRIPTION
This tracks when an editor has been modified, shows the user a visual indication (in this case, a `*`), and asks for confirmation before deleting a tab.

### Visual indicator
<img width="493" alt="Screen Shot 2022-01-07 at 13 50 04" src="https://user-images.githubusercontent.com/1118185/148592373-216fda10-d29b-46a3-baa1-33fb5e853a25.png">

### Confirmation request
<img width="1093" alt="Screen Shot 2022-01-07 at 13 50 09" src="https://user-images.githubusercontent.com/1118185/148592376-636be0f1-0a60-4c17-93a6-faadda22c989.png">

## Limitations

Does not understand when a file has been returned to its original state, so only a save will reset the `dirty` state to `clean`.