### PR TITLE
Fixed some weird font behavior on windows for default monospace font

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -242,7 +242,7 @@
        <widget class="QDoubleSpinBox" name="brakeCurrentBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -405,7 +405,7 @@
        <widget class="QDoubleSpinBox" name="speedBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -438,7 +438,7 @@
        <widget class="QDoubleSpinBox" name="handbrakeBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -468,7 +468,7 @@
        <widget class="QDoubleSpinBox" name="dutyBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -532,7 +532,7 @@
        <widget class="QDoubleSpinBox" name="posBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -559,7 +559,7 @@
        <widget class="QDoubleSpinBox" name="currentBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">

--- a/map/mapwidget.cpp
+++ b/map/mapwidget.cpp
@@ -1297,7 +1297,7 @@ int MapWidget::drawInfoPoints(QPainter &painter, const QList<LocPoint> &pts,
                 pt_txt.setY(p.y());
                 pt_txt = drawTrans.map(pt_txt);
                 painter.setPen(Qt::black);
-                painter.setFont(QFont("monospace"));
+                painter.setFont(QFont("DejaVu Sans Mono"));
                 rect_txt.setCoords(pt_txt.x(), pt_txt.y() - 20,
                                    pt_txt.x() + 500, pt_txt.y() + 500);
                 painter.drawText(rect_txt, Qt::AlignTop | Qt::AlignLeft, ip.getInfo());
@@ -1672,7 +1672,7 @@ void MapWidget::paint(QPainter &painter, int width, int height, bool highQuality
 
     // Set font
     font.setPointSize(10);
-    font.setFamily("Monospace");
+    font.setFamily("DejaVu Sans Mono");
     painter.setFont(font);
 
     // Grid parameters

--- a/widgets/detectbldc.ui
+++ b/widgets/detectbldc.ui
@@ -29,7 +29,7 @@
          <widget class="QDoubleSpinBox" name="dutyBox">
           <property name="font">
            <font>
-            <family>Monospace</family>
+            <family>DejaVu Sans Mono</family>
            </font>
           </property>
           <property name="toolTip">
@@ -56,7 +56,7 @@
          <widget class="QDoubleSpinBox" name="currentBox">
           <property name="font">
            <font>
-            <family>Monospace</family>
+            <family>DejaVu Sans Mono</family>
            </font>
           </property>
           <property name="toolTip">
@@ -100,7 +100,7 @@
          <widget class="QDoubleSpinBox" name="erpmBox">
           <property name="font">
            <font>
-            <family>Monospace</family>
+            <family>DejaVu Sans Mono</family>
            </font>
           </property>
           <property name="toolTip">

--- a/widgets/detectfoc.cpp
+++ b/widgets/detectfoc.cpp
@@ -245,7 +245,7 @@ void DetectFoc::on_applyAllButton_clicked()
         if (lambda < 1e-10) {
             QMessageBox::critical(this,
                                   tr("Apply Error"),
-                                  tr("\u03BB is 0. Please measure it first."));
+                                  tr(u8"\u03BB is 0. Please measure it first."));
             return;
         }
 
@@ -261,7 +261,7 @@ void DetectFoc::on_applyAllButton_clicked()
         mVesc->mcConfig()->updateParamDouble("foc_motor_ld_lq_diff", ld_lq_diff / 1e6);
         mVesc->mcConfig()->updateParamDouble("foc_motor_flux_linkage", lambda);
 
-        mVesc->emitStatusMessage(tr("R, L and \u03BB applied"), true);
+        mVesc->emitStatusMessage(tr(u8"R, L and \u03BB applied"), true);
 
         if (mTempMotorLast > -10.0) {
             mVesc->mcConfig()->updateParamDouble("foc_temp_comp_base_temp", mTempMotorLast);
@@ -372,7 +372,7 @@ void DetectFoc::on_calcGainButton_clicked()
     if (lambda < 1e-10) {
         QMessageBox::critical(this,
                               tr("Calculate Error"),
-                              tr("\u03BB is 0. Please measure it first."));
+                              tr(u8"\u03BB is 0. Please measure it first."));
         return;
     }
 

--- a/widgets/detectfoc.ui
+++ b/widgets/detectfoc.ui
@@ -52,7 +52,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -92,7 +92,7 @@
        <widget class="QDoubleSpinBox" name="obsGainBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -132,7 +132,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -162,7 +162,7 @@
        <widget class="QDoubleSpinBox" name="currentBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -239,7 +239,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -437,7 +437,7 @@
        <widget class="QDoubleSpinBox" name="dutyBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -470,7 +470,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="readOnly">
@@ -494,7 +494,7 @@
        <widget class="QDoubleSpinBox" name="erpmBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -538,7 +538,7 @@
        <widget class="QDoubleSpinBox" name="kiBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -574,7 +574,7 @@
        <widget class="QDoubleSpinBox" name="kpBox">
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">
@@ -616,7 +616,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Monospace</family>
+          <family>DejaVu Sans Mono</family>
          </font>
         </property>
         <property name="toolTip">

--- a/widgets/displaybar.cpp
+++ b/widgets/displaybar.cpp
@@ -56,7 +56,7 @@ void DisplayBar::paintEvent(QPaintEvent *event)
 
     // Name
     pen.setColor(Utility::getAppQColor("white"));
-    font.setFamily("Monospace");
+    font.setFamily("DejaVu Sans Mono");
     font.setBold(true);
     font.setPixelSize(h * f_val - 2);
     painter.setPen(pen);
@@ -66,7 +66,7 @@ void DisplayBar::paintEvent(QPaintEvent *event)
 
     // Value
     pen.setColor(Utility::getAppQColor("white"));
-    font.setFamily("Monospace");
+    font.setFamily("DejaVu Sans Mono");
     font.setBold(true);
     font.setPixelSize(h * f_val - 2);
     painter.setPen(pen);

--- a/widgets/displaypercentage.cpp
+++ b/widgets/displaypercentage.cpp
@@ -114,7 +114,7 @@ void DisplayPercentage::paintEvent(QPaintEvent *event)
 
     // Text
     pen.setColor(c_text);
-    font.setFamily("Monospace");
+    font.setFamily("DejaVu Sans Mono");
     font.setBold(true);
     font.setPixelSize(2 * h / 3 - 2);
     painter.setPen(pen);

--- a/widgets/mrichtextedit.cpp
+++ b/widgets/mrichtextedit.cpp
@@ -379,7 +379,7 @@ void MRichTextEdit::textStyle(int index) {
     }
     if (index == ParagraphMonospace) {
         fmt = cursor.charFormat();
-        fmt.setFontFamily("Monospace");
+        fmt.setFontFamily("DejaVu Sans Mono");
         fmt.setFontStyleHint(QFont::Monospace);
         fmt.setFontFixedPitch(true);
     }
@@ -611,7 +611,7 @@ void MRichTextEdit::fontChanged(const QFont &f) {
     } else if (f.pointSize() == m_fontsize_h4) {
         f_paragraph->setCurrentIndex(ParagraphHeading4);
     } else {
-        if (f.fixedPitch() && f.family() == "Monospace") {
+        if (f.fixedPitch() && f.family() == "DejaVu Sans Mono") {
             f_paragraph->setCurrentIndex(ParagraphMonospace);
         } else {
             f_paragraph->setCurrentIndex(ParagraphStandard);


### PR DESCRIPTION
The tool  was pulling a default monospace font that didn't have symbols for many of  the greek letters. This seems to fix it, hopefully it doesn't do anything funny on other platforms but deja vu sans mono should always be packaged in the resources so I don't see why it would. 