### PR TITLE
Fixed firmware version dropping the zero

### DIFF
--- a/pages/pagefirmware.cpp
+++ b/pages/pagefirmware.cpp
@@ -159,7 +159,7 @@ void PageFirmware::fwRxChanged(bool rx, bool limited)
     }
 
     if (params.major >= 0) {
-        fwStr = QString("Fw: %1.%2").arg(params.major).arg(params.minor);
+        fwStr = QString("Fw: %1.%2").arg(params.major).arg(params.minor, 2, 10, QLatin1Char('0'));
         if (!params.hw.isEmpty()) {
             fwStr += ", Hw: " + params.hw;
         }

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -505,7 +505,7 @@ QStringList VescInterface::getSupportedFirmwares()
     QStringList fws;
 
     for (int i = 0;i < fwPairs.size();i++) {
-        fws.append(QString("%1.%2").arg(fwPairs.at(i).first).arg(fwPairs.at(i).second));
+        fws.append(QString("%1.%2").arg(fwPairs.at(i).first).arg(fwPairs.at(i).second, 2, 10, QLatin1Char('0')));
     }
     return fws;
 }


### PR DESCRIPTION
Changes how the firmware string is displayed so it's always 2 digits for the minor version, even if there is a leading zero.

Previous
![old_display](https://user-images.githubusercontent.com/628881/152452927-5fac6b48-3c07-4c43-aa9f-74ae6a4ce998.png)

Updated
![new_display](https://user-images.githubusercontent.com/628881/152452935-0c356c6a-9725-4b1d-ad04-1316ea6bf2dd.png)

It will also work will work with two digit minor versions and not add an extra zero
![future_display](https://user-images.githubusercontent.com/628881/152452939-45307b58-2b8c-4098-865d-55d392aa33a0.png)
