### PR TITLE
Fixed FW upload freezing UI on ios

### DIFF
--- a/mobile/FwUpdate.qml
+++ b/mobile/FwUpdate.qml
@@ -452,24 +452,17 @@ Item {
 
         onAccepted: {
             var okUploadFw = false
-
             if (swipeView.currentIndex == 0) {
                 if (mCommands.getLimitedSupportsEraseBootloader() && blItems.count > 0) {
-                    fwHelper.uploadFirmware(blItems.get(blBox.currentIndex).value, VescIf, true, false, fwdCan)
+                    fwHelper.uploadFirmwareSingleShotTimer(fwItems.get(fwBox.currentIndex).value, VescIf, false, false,
+                                                           fwdCan, blItems.get(blBox.currentIndex).value)
+                } else {
+                    okUploadFw = fwHelper.uploadFirmwareSingleShotTimer(fwItems.get(fwBox.currentIndex).value, VescIf, false, false, fwdCan, "")
                 }
-                okUploadFw = fwHelper.uploadFirmware(fwItems.get(fwBox.currentIndex).value, VescIf, false, false, fwdCan)
             } else if (swipeView.currentIndex == 1) {
-                okUploadFw = fwHelper.uploadFirmware(customFwText.text, VescIf, false, true, fwdCan)
+                okUploadFw = fwHelper.uploadFirmwareSingleShotTimer(customFwText.text, VescIf, false, true, fwdCan,"")
             } else if (swipeView.currentIndex == 2) {
-                fwHelper.uploadFirmware(blItems.get(blBox.currentIndex).value, VescIf, true, false, fwdCan)
-            }
-
-            if (okUploadFw) {
-                VescIf.emitMessageDialog("Warning",
-                                         "The firmware upload is done. You must wait at least " +
-                                         "10 seconds before unplugging power. Otherwise the firmware will get corrupted and your " +
-                                         "VESC will become bricked. If that happens you need a SWD programmer to recover it.",
-                                         true, false)
+                fwHelper.uploadFirmwareSingleShotTimer(blItems.get(blBox.currentIndex).value, VescIf, true, false, fwdCan,"")
             }
         }
     }
@@ -641,6 +634,25 @@ Item {
             uploadProgress.value = progress
             uploadButton.enabled = !isOngoing
             cancelButton.enabled = isOngoing
+        }
+    }
+    Connections {
+        target: fwHelper
+
+        onFwUploadRes: {
+            if (res) {
+                if(isBootloader) {
+                        VescIf.emitMessageDialog("Bootloader Finished",
+                                                 "Bootloader upload is done.",
+                                                 true, false)
+                } else {
+                        VescIf.emitMessageDialog("Warning",
+                                                 "The firmware upload is done. You must wait at least " +
+                                                 "10 seconds before unplugging power. Otherwise the firmware will get corrupted and your " +
+                                                 "VESC will become bricked. If that happens you need a SWD programmer to recover it.",
+                                                 true, false)
+                }
+            }
         }
     }
 

--- a/mobile/fwhelper.cpp
+++ b/mobile/fwhelper.cpp
@@ -175,3 +175,22 @@ bool FwHelper::uploadFirmware(QString filename, VescInterface *vesc,
 
     return fwRes;
 }
+
+bool FwHelper::uploadFirmwareSingleShotTimer(QString filename, VescInterface *vesc,
+                              bool isBootloader, bool checkName, bool fwdCan, QString BLfilename)
+{
+    bool res;
+    QTimer::singleShot(10, [this, &res, filename, vesc, isBootloader, checkName, fwdCan, BLfilename]() {
+        qDebug() << filename;
+        if(BLfilename.isEmpty()) {
+            res = uploadFirmware(filename, vesc, isBootloader, checkName, fwdCan);
+        } else {
+            res = uploadFirmware(BLfilename, vesc, true, checkName, fwdCan);
+            if(res) {
+                res = uploadFirmware(filename, vesc, isBootloader, checkName, fwdCan);
+            }
+        }
+        emit fwUploadRes(res, isBootloader);
+    });
+    return true;
+}

--- a/mobile/fwhelper.h
+++ b/mobile/fwhelper.h
@@ -34,8 +34,12 @@ public:
     Q_INVOKABLE QVariantMap getBootloaders(FW_RX_PARAMS params, QString hw);
     Q_INVOKABLE bool uploadFirmware(QString filename, VescInterface *vesc,
                                     bool isBootloader, bool isIncluded, bool fwdCan);
+    Q_INVOKABLE bool uploadFirmwareSingleShotTimer(QString filename, VescInterface *vesc,
+                                                 bool isBootloader, bool isIncluded, bool fwdCan, QString BLfilename);
 
 signals:
+
+    void fwUploadRes(bool res, bool isBootloader);
 
 public slots:
 };


### PR DESCRIPTION
Changes to use single shot timer to avoid bloacking QML ui on fw upload execution. For some reason only seemed to be an issue on iOS. 