### PR TITLE
This will trigger a reconnection event in the event that the device g…

### DIFF
--- a/bleuart.h
+++ b/bleuart.h
@@ -47,6 +47,7 @@ signals:
     void scanDone(QVariantMap devs, bool done);
     void bleError(QString info);
     void connected();
+    void unintentionalDisconnect();
 
 public slots:
     void writeData(QByteArray data);
@@ -63,6 +64,7 @@ private slots:
     void deviceDisconnected();
 
     void serviceStateChanged(QLowEnergyService::ServiceState s);
+    void serviceError(QLowEnergyService::ServiceError e);
     void updateData(const QLowEnergyCharacteristic &c, const QByteArray &value);
     void confirmedDescriptorWrite(const QLowEnergyDescriptor &d, const QByteArray &value);
 
@@ -82,7 +84,7 @@ private:
     QString mTxUuid;
     bool mScanFinished;
     bool mInitDone;
-    QTimer mConnectTimetoutTimer;
+    QTimer mConnectTimeoutTimer;
 
     void init();
 

--- a/mobile/FwUpdate.qml
+++ b/mobile/FwUpdate.qml
@@ -646,6 +646,7 @@ Item {
                                                  "Bootloader upload is done.",
                                                  true, false)
                 } else {
+                        VescIf.disconnectPort()
                         VescIf.emitMessageDialog("Warning",
                                                  "The firmware upload is done. You must wait at least " +
                                                  "10 seconds before unplugging power. Otherwise the firmware will get corrupted and your " +

--- a/pages/pagelisp.cpp
+++ b/pages/pagelisp.cpp
@@ -18,6 +18,8 @@
     */
 
 #include <QDateTime>
+#include <QMessageBox>
+#include <QProgressDialog>
 #include "pagelisp.h"
 #include "ui_pagelisp.h"
 #include "utility.h"

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -193,6 +193,7 @@ VescInterface::VescInterface(QObject *parent) : QObject(parent)
         setLastConnectionType(CONN_BLE);
         mSettings.setValue("ble_addr", mLastBleAddr);
     });
+    connect(mBleUart, SIGNAL(unintentionalDisconnect()), this, SLOT(bleUnintentionalDisconnect()));
 #endif
 
     mTcpServer = new TcpServerSimple(this);
@@ -2899,6 +2900,11 @@ void VescInterface::udpInputError(QAbstractSocket::SocketError socketError)
 void VescInterface::bleDataRx(QByteArray data)
 {
     mPacket->processData(data);
+}
+
+void VescInterface::bleUnintentionalDisconnect()
+{
+   emit unintentionalBleDisconnect();
 }
 #endif
 

--- a/vescinterface.h
+++ b/vescinterface.h
@@ -242,6 +242,7 @@ signals:
     void autoConnectFinished();
     void profilesUpdated();
     void pairingListUpdated();
+    void unintentionalBleDisconnect();
     void CANbusNewNode(int node);
     void CANbusInterfaceListUpdated();
     void useImperialUnitsChanged(bool useImperialUnits);
@@ -273,6 +274,7 @@ private slots:
 
 #ifdef HAS_BLUETOOTH
     void bleDataRx(QByteArray data);
+    void bleUnintentionalDisconnect();
 #endif
 
     void timerSlot();


### PR DESCRIPTION
…oes out of range or is shutdown remotely. Tries 5 times each second then gives up and opens connection menu

We could consider having this as an app setting to say how many retries we want to do. Sometimes when I ride with my phone in my pocket in dense areas I get momentary disconnects that cause my logs to stop. No more I say! Really need to test a bit more to be sure this doesn't cause any funny behaviors but so far so good. 

The key here was to catch the event of invalidService which seems to only trigger when the device goes out of range or turns off. 