### PR TITLE
FwUpdate.qml: refresh version strings when load is completed

### DIFF
--- a/mobile/FwUpdate.qml
+++ b/mobile/FwUpdate.qml
@@ -145,6 +145,21 @@ Item {
 
                             Component.onCompleted: {
                                 updateHw(VescIf.getLastFwRxParams())
+                                var params = VescIf.getLastFwRxParams()
+
+                                updateHw(params)
+                                updateBl(params)
+
+                                var testFwStr = "";
+
+                                if (params.isTestFw > 0) {
+                                    testFwStr = " BETA " +  params.isTestFw
+                                }
+
+                                versionText.text =
+                                        "FW   : " + params.major + "." + params.minor + testFwStr + "\n" +
+                                        "HW   : " + params.hw + "\n" +
+                                        "UUID : " + Utility.uuid2Str(params.uuid, false)
                             }
 
                             onCurrentIndexChanged: {


### PR DESCRIPTION
When you call the FwUpdate QML from a custom QML UI, it lacks the FW, HW, and UUID version strings.

This happens because that text is filled only after the initial connection, but when the custom QML UI is loaded, that initial connection happened long ago.

This PR fixes this by setting the version text when the FwUpdate QML load has been completed.

I tested a bunch of firmwares and I don't see it breaking things, but I might be missing something.