### PR TITLE
Make gauge cluster settings dialog work in HwUi and AppUi

### DIFF
--- a/mobile/RtDataSetup.qml
+++ b/mobile/RtDataSetup.qml
@@ -32,7 +32,7 @@ import Vedder.vesc.configparams 1.0
 
 Item {
     id: rtData
-    property var dialogParent: ApplicationWindow.overlay
+    property var dialogParent: ApplicationWindow.overlay // not used internally, kept for backwards compatibility
     anchors.fill: parent
     property alias updateData: commandsUpdate.enabled
 
@@ -175,9 +175,9 @@ Item {
                             color: "#AA000000"
                         }
 
-                        x: 10
-                        y: Math.max((parent.height - height) / 2, 10)
-                        parent: dialogParent
+                        x: Math.round((parent.width - width) / 2)
+                        y: Math.round((parent.height - height) / 2)
+                        parent: rtData
                         standardButtons: Dialog.Ok | Dialog.Cancel
 
                         onOpened: {

--- a/res/qml/WelcomeQmlPanel.qml
+++ b/res/qml/WelcomeQmlPanel.qml
@@ -234,7 +234,6 @@ Item {
                     Page {
                         RtDataSetup {
                             anchors.fill: parent
-                            dialogParent: container
                         }
                     }
 


### PR DESCRIPTION
The dialog was attached to ApplicationWindow which didn't work when
you call it from a custom HwUi or AppUi QML.
Interestingly, it only failed on the actual phone app, it always worked in the desktop vesc tool

If you delete dialogParent declaration the app crashes when you use it like in WelcomeQmlPanel, so I kept the declaration to avoid breaking other people custom QMLs out there.


