### PR TITLE
Make Upload All button optional for custom QMLUIs

### DIFF
--- a/mobile/FwUpdate.qml
+++ b/mobile/FwUpdate.qml
@@ -32,6 +32,7 @@ Item {
     property Commands mCommands: VescIf.commands()
     property ConfigParams mInfoConf: VescIf.infoConfig()
     property bool isHorizontal: width > height
+    property bool showUploadAllButton: true
     anchors.fill: parent
 
     FwHelper {
@@ -431,6 +432,7 @@ Item {
                         id: uploadAllButton
                         text: qsTr("Upload All")
                         Layout.fillWidth: true
+                        visible: showUploadAllButton
 
                         onClicked: {
                             uploadFw(true)


### PR DESCRIPTION
Its very handy to reuse the FwUpdate.qml, but users got confused by the UPLOAD ALL button, they don't know if UPLOAD or UPLOAD ALL should be used.

Exposing this new `showUploadAllButton` property the custom qmlUI can hide those buttons for applications where no other VESCs will be present in the canbus network.