### PR TITLE
If available, append FW_NAME to the firmware version

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -152,6 +152,10 @@ void Commands::processPacket(QByteArray data)
             params.nrfPinSupported = nrfFlags & 2;
         }
 
+        if (vb.size() >= 1) {
+            params.fwName = vb.vbPopFrontString();
+        }
+
         emit fwVersionReceived(params);
     } break;
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -566,6 +566,7 @@ struct FW_RX_PARAMS {
 
     Q_PROPERTY(int major MEMBER major)
     Q_PROPERTY(int minor MEMBER minor)
+    Q_PROPERTY(QString fwName MEMBER fwName)
     Q_PROPERTY(QString hw MEMBER hw)
     Q_PROPERTY(QByteArray uuid MEMBER uuid)
     Q_PROPERTY(bool isPaired MEMBER isPaired)
@@ -617,6 +618,7 @@ public:
 
     int major;
     int minor;
+    QString fwName;
     QString hw;
     QByteArray uuid;
     bool isPaired;

--- a/mobile/FwUpdate.qml
+++ b/mobile/FwUpdate.qml
@@ -152,13 +152,19 @@ Item {
                                 updateBl(params)
 
                                 var testFwStr = "";
+                                var fwNameStr = "";
 
                                 if (params.isTestFw > 0) {
                                     testFwStr = " BETA " +  params.isTestFw
                                 }
 
+ 
+                                if (params.fwName !== "") {
+                                    fwNameStr = " (" + params.fwName + ")"
+                                }
+                                    
                                 versionText.text =
-                                        "FW   : " + params.major + "." + params.minor + testFwStr + "\n" +
+                                        "FW   : v" + params.major + "." + params.minor + fwNameStr + testFwStr + "\n" +
                                         "HW   : " + params.hw + "\n" +
                                         "UUID : " + Utility.uuid2Str(params.uuid, false)
                             }
@@ -711,13 +717,18 @@ Item {
             updateBl(params)
 
             var testFwStr = "";
+            var fwNameStr = "";
 
             if (params.isTestFw > 0) {
                 testFwStr = " BETA " +  params.isTestFw
             }
 
+            if (params.fwName !== "") {
+                fwNameStr = " (" + params.fwName + ")"
+            }
+
             versionText.text =
-                    "FW   : " + params.major + "." + params.minor + testFwStr + "\n" +
+                    "FW   : v" + params.major + "." + params.minor + fwNameStr + testFwStr + "\n" +
                     "HW   : " + params.hw + "\n" +
                     "UUID : " + Utility.uuid2Str(params.uuid, false)
         }

--- a/pages/pagefirmware.cpp
+++ b/pages/pagefirmware.cpp
@@ -159,7 +159,11 @@ void PageFirmware::fwRxChanged(bool rx, bool limited)
     }
 
     if (params.major >= 0) {
-        fwStr = QString("Fw: %1.%2").arg(params.major).arg(params.minor, 2, 10, QLatin1Char('0'));
+        fwStr = QString("Fw: v%1.%2").arg(params.major).arg(params.minor, 2, 10, QLatin1Char('0'));
+        if (!params.fwName.isEmpty()) {
+            fwStr += " (" + params.fwName + ")";
+        }
+
         if (!params.hw.isEmpty()) {
             fwStr += ", Hw: " + params.hw;
         }


### PR DESCRIPTION
Some firmwares come in `default` and `default_no_hw_limits` flavors, this helps showing which flavor it is running.

In our particular case, the MAJOR.MINOR version naming for stable releases is not enough, as we need to release patches or small improvements and we can't show which one of those builds were used.

Here are examples of how this PR looks like:

FW_NAME empty:
![image](https://user-images.githubusercontent.com/309472/166394562-64403940-f11e-4fe2-a4f9-bc63bcf199f1.png)

Showing no_hw_limits
![image](https://user-images.githubusercontent.com/309472/166394280-211e403d-61be-4c58-826e-c7db749a10ee.png)

Tesla style
![image](https://user-images.githubusercontent.com/309472/166394461-95e8300b-5424-4c2f-a3f3-79066c26e706.png)

App:
![image](https://user-images.githubusercontent.com/309472/166393190-88e6b38b-cb4d-4504-bad1-c59850a8762d.png)

If you're ok with this contribution let me know and I'll create the PR on the firmware side, its ready to go.