### PR TITLE
Support for Little FOCer V3 and V3.1

### DIFF
--- a/res/firmwares/res_fw.qrc
+++ b/res/firmwares/res_fw.qrc
@@ -55,7 +55,8 @@
         <file>STORMCORE_100S/VESC_default.bin</file>
         <file>STORMCORE_100S/VESC_default_no_hw_limits.bin</file>
         <file>Little_FOCer/VESC_default.bin</file>
-        <file>Little_FOCer/VESC_default_no_hw_limits.bin</file>
+        <file>Little_FOCer_V3/VESC_default.bin</file>
+        <file>Little_FOCer_V3_1/VESC_default.bin</file>
         <file>UXV_SR/VESC_default.bin</file>
         <file>GESC/VESC_default.bin</file>
         <file>Warrior6/VESC_default.bin</file>


### PR DESCRIPTION
There's 3 Little FOCer variants:
V1 (the original, supported since fw5.3)
V3 (new version without DRV chip)
V3.1 (new variant of V3 with LSM6DS3 IMU)

Also removed the no-limits version.

Signed-off-by: Dado Mista <dadomista@gmail.com>