### PR TITLE
Improvements for M365 Dashboard Lisp

### DIFF
--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -38,7 +38,7 @@
 (define presses 0)
 
 (define off 0)
-(define locked 0)
+(define lock 0)
 (define speedmode 1)
 
 (defun inp (buffer) ;Frame 0x65
@@ -54,7 +54,7 @@
             (if (= speedmode 4) ; is sport?
                 (print "sport"))))
     
-    (if (= (+ off locked) 0)
+    (if (= (+ off lock) 0)
         (progn
             (if (> (* (get-speed) 3.6) min-speed)
                 (set-current-rel throttle)
@@ -65,7 +65,7 @@
         )
         (progn
             (set-current-rel 0)
-            (if (= locked 1)
+            (if (= lock 1)
                 (if (> (* (get-speed) 3.6) min-speed)
                     (set-brake-rel 1)
                     (set-brake-rel 0)
@@ -143,7 +143,7 @@
                             ;; (4 (setvar 'speedmode 2)))
                             
                             (if (> brake 0.02)
-                                (setvar 'locked (bitwise-xor locked 1))
+                                (setvar 'lock (bitwise-xor lock 1))
                                 (if (= speedmode 1) ; is drive?
                                     (setvar 'speedmode 4) ; to sport
                                     (if (= speedmode 2) ; is eco?
@@ -171,7 +171,7 @@
     
         (if (= off 1)
             (bufset-u8 tx-frame 6 16) ; turn off display
-            (if (= locked 1)
+            (if (= lock 1)
                 (bufset-u8 tx-frame 6 32)
                 (bufset-u8 tx-frame 6 speedmode)
             )

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -29,10 +29,9 @@
 (define throttle 0)
 (define brake 0)
 (define buttonold 0)
-(define light 1)
+(define light 0)
 (setvar 'light light-default)
 (define c-out 0)
-(define battery 100)
 (define code 0)
 
 (define presstime (systime))

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -55,12 +55,28 @@
             (if (= speedmode 4) ; is sport?
                 (print "sport"))))
     
-    (if (> (* (get-speed) 3.6) min-speed)
-        (set-current-rel throttle)
-        (set-current-rel 0))
+    (if (= (+ off locked) 0)
+        (progn
+            (if (> (* (get-speed) 3.6) min-speed)
+                (set-current-rel throttle)
+                (set-current-rel 0))
+                
+            (if (> brake 0.02)
+                (set-brake-rel brake))
+        )
+        (progn
+            (set-current-rel 0)
+            (if (= locked 1)
+                (if (> (* (get-speed) 3.6) min-speed)
+                    (set-brake-rel 1)
+                    (set-brake-rel 0)
+                )
+                (set-brake-rel 0)
+            )
+        )
+    )
     
-    (if (> brake 0.02)
-        (set-brake-rel brake))
+    
 ))
 
 (defun outp (buffer) ;Frame 0x64
@@ -127,13 +143,15 @@
                             ;; (2 (setvar 'speedmode 1))
                             ;; (4 (setvar 'speedmode 2)))
                             
-                            (if (= speedmode 1) ;; is drive?
-                                (setvar 'speedmode 4) ;; to sport
-                                (if (= speedmode 2) ;; is eco?
-                                    (setvar 'speedmode 1) ;; to drive
-                                    (if (= speedmode 4) ;; is sport?
-                                        (setvar 'speedmode 2)))) ;; to eco
-                            
+                            (if (> brake 0.02)
+                                (setvar 'locked (bitwise-xor locked 1))
+                                (if (= speedmode 1) ; is drive?
+                                    (setvar 'speedmode 4) ; to sport
+                                    (if (= speedmode 2) ; is eco?
+                                        (setvar 'speedmode 1) ; to drive
+                                        (if (= speedmode 4) ; is sport?
+                                            (setvar 'speedmode 2)))) ; to eco
+                            )
                         )
                     )
                 

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -39,7 +39,6 @@
     (progn
     (setvar 'throttle (/(-(bufget-u8 uart-buf 4) cal-thr-lo) cal-thr-hi))
     (setvar 'brake (/(-(bufget-u8 uart-buf 5) cal-brk-lo) cal-brk-hi))
-    (set-current-rel 0)
     (if (> (* (get-speed) 3.6) min-speed)
         (set-current-rel throttle)
         (set-current-rel 0))

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -220,7 +220,7 @@
 
 (loopwhile t
     (progn
-        ; If you do not have any R470 resistors or it still occours to press buttons randomly, try uncommenting this:
+        ; Random button presses can occour (while braking as ex.), that's why I decided to disable button interaction while driving by default.
         (if (<= (* (get-speed) 3.6) min-speed)
         (progn
             (if (> buttonold (gpio-read 'pin-rx))
@@ -255,7 +255,7 @@
                             
                             (if (>= presses 2) ; double press
                                 (progn
-                                    (if (> brake 0.02)
+                                    (if (> (/(- brake-in cal-brk-lo) cal-brk-hi) brk-deadzone)
                                         (setvar 'lock (bitwise-xor lock 1))
                                         (progn
                                             (if (= speedmode 1) ; is drive?

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -188,6 +188,7 @@
     (progn
         ; If you do not have any R470 resistors or it still occours to press buttons randomly, try uncommenting this:
         ;(if (<= (* (get-speed) 3.6) min-speed)
+        ;(progn
             (if (> buttonold (gpio-read 'pin-rx))
                 (progn
                     (setvar 'presses (+ presses 1))
@@ -256,7 +257,7 @@
             )
 
             (setvar 'buttonold (gpio-read 'pin-rx))
-        ;)
+        ;))
         (sleep 0.01)
     )
 )

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -220,7 +220,7 @@
 
 (loopwhile t
     (progn
-        ; Random button presses can occour (while braking as ex.), that's why I decided to disable button interaction while driving by default.
+        ; If you do not have any R470 resistors or it still occours to press buttons randomly, try uncommenting this:
         (if (<= (* (get-speed) 3.6) min-speed)
         (progn
             (if (> buttonold (gpio-read 'pin-rx))
@@ -255,7 +255,7 @@
                             
                             (if (>= presses 2) ; double press
                                 (progn
-                                    (if (> (/(- brake-in cal-brk-lo) cal-brk-hi) brk-deadzone)
+                                    (if (> brake 0.02)
                                         (setvar 'lock (bitwise-xor lock 1))
                                         (progn
                                             (if (= speedmode 1) ; is drive?

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -1,14 +1,19 @@
-; M365 dashboard compability lisp script by Netzpfuscher
-; Wiring: red=5V black=GND yellow=COM-TX (UART-HDX) green=COM-RX (button)+3.3V with R470 Resistor
+; M365 dashboard compability lisp script by Netzpfuscher and 1zuna
+; Tested with Flipsky 75100 on COMM connector
+; UART Wiring: red=5V black=GND yellow=COM-TX (UART-HDX) green=COM-RX (button)+3.3V with R470 Resistor
+; German guide: https://rollerplausch.com/threads/vesc-controller-einbau-1s-pro2-g30.6032/
 
 ; **** User parameters ****
 ;Calibrate throttle min max
 (define cal-thr-lo 41.0)
-(define cal-thr-hi 178.0)
+(define cal-thr-hi 167.0)
+(define thr-deadzone 0.05)
 
 ;Calibrate brake min max
-(define cal-brk-lo 40.0)
-(define cal-brk-hi 178.0)
+(define cal-brk-lo 39.0)
+(define cal-brk-hi 179.0)
+(define brk-deadzone 0.05)
+(define brk-minspeed 1)
 
 (define light-default 0)
 (define show-faults 1)
@@ -33,7 +38,10 @@
 (bufset-u16 tx-frame 4 0x6400)
 
 (define uart-buf (array-create type-byte 64))
+(define current-speed 0)
+(define throttle-in 0)
 (define throttle 0)
+(define brake-in 0)
 (define brake 0)
 (define buttonold 0)
 (define light 0)
@@ -61,26 +69,52 @@
 
 (defun inp(buffer) ; Frame 0x65
     (progn
-        (setvar 'throttle (/(-(bufget-u8 uart-buf 4) cal-thr-lo) cal-thr-hi))
-        (setvar 'brake (/(-(bufget-u8 uart-buf 5) cal-brk-lo) cal-brk-hi))
+        (setvar 'current-speed (* (get-speed) 3.6))
+        
+        ; Throttle
+        (setvar 'throttle-in (bufget-u8 uart-buf 4))
+        (setvar 'throttle (/(- throttle-in cal-thr-lo) cal-thr-hi))
+        
+        (if (< throttle thr-deadzone)
+            (setvar 'throttle 0)
+        )
+        (if (> throttle 1)
+            (setvar 'throttle 1)
+        )
+        
+        ; Brake
+        (setvar 'brake-in (bufget-u8 uart-buf 5))
+        (setvar 'brake (/(- brake-in cal-brk-lo) cal-brk-hi))
+        
+        (if(< brake brk-deadzone)
+            (setvar 'brake 0)
+        )
+        (if (< current-speed brk-minspeed)
+            (setvar 'brake 0)
+        )
+        (if (> brake 1)
+            (setvar 'brake 1)
+        )
 
         (if (= (+ off lock) 0)
-            (progn
-                (if (> (* (get-speed) 3.6) min-speed)
+            (progn ; Driving mode
+                (if (> current-speed min-speed)
                     (set-current-rel throttle)
-                    (set-current-rel 0))
-                
-                (if (> brake 0.02)
-                    (set-brake-rel brake))
+                    (set-current-rel 0)
+                )
+                (if (not (= brake 0))
+                    (set-brake-rel brake)
+                )
             )
             (progn
-                (set-current-rel 0)
-                (if (= lock 1)
-                    (if (> (* (get-speed) 3.6) min-speed)
-                        (set-brake-rel 1)
-                        (set-brake-rel 0)
+                (set-current-rel 0) ; No throttle input when off or locked
+                
+                (if (= lock 1) ; Check if it is locked
+                    (if (> current-speed min-speed) ; Brake when being pushed while locked
+                        (set-brake-rel 1) ; Full power brake
+                        (set-brake-rel 0) ; No brake
                     )
-                    (set-brake-rel 0)
+                    (set-brake-rel 0) ; No brake input when off
                 )
             )
         )
@@ -187,8 +221,8 @@
 (loopwhile t
     (progn
         ; If you do not have any R470 resistors or it still occours to press buttons randomly, try uncommenting this:
-        ;(if (<= (* (get-speed) 3.6) min-speed)
-        ;(progn
+        (if (<= (* (get-speed) 3.6) min-speed)
+        (progn
             (if (> buttonold (gpio-read 'pin-rx))
                 (progn
                     (setvar 'presses (+ presses 1))
@@ -257,7 +291,7 @@
             )
 
             (setvar 'buttonold (gpio-read 'pin-rx))
-        ;))
+        ))
         (sleep 0.01)
     )
 )

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -168,20 +168,27 @@
                 )
             )
         )
-    
+
+        ; mode field (1=drive, 2=eco, 4=sport, 8=charge, 16=off, 32=lock)
         (if (= off 1)
             (bufset-u8 tx-frame 6 16) ; turn off display
             (if (= lock 1)
-                (bufset-u8 tx-frame 6 32)
+                (bufset-u8 tx-frame 6 32) ; lock display
                 (bufset-u8 tx-frame 6 speedmode)
             )
         )
         
+        ; batt field
         (bufset-u8 tx-frame 7 (*(get-batt) 100))
+        ; light field
         (if (= off 0)
             (bufset-u8 tx-frame 8 light)
             (bufset-u8 tx-frame 8 0)
         )
+
+        ; todo: add beeping on lock when pushing scooter
+
+        ; speed field
         (if (= show-batt-in-idle 1)
             (if (> (* (get-speed) 3.6) 1)
                 (bufset-u8 tx-frame 10 (* (get-speed) 3.6))
@@ -190,7 +197,7 @@
         )
         
         (if (= show-faults 1)
-        (bufset-u8 tx-frame 11 (get-fault))
+            (bufset-u8 tx-frame 11 (get-fault))
         )
         (sleep 0.1)
 ))-

--- a/res/Lisp/Examples/m365_dash.lisp
+++ b/res/Lisp/Examples/m365_dash.lisp
@@ -53,7 +53,7 @@
 (define speedmode 4)
 
 (conf-set 'max-speed (/ speed-sport 3.6))
-(conf-set 'l-watt-max (/ watt-sport 3.6))
+(conf-set 'l-watt-max watt-sport)
 
 ; Sound feedback
 
@@ -227,19 +227,19 @@
                                             (if (= speedmode 1) ; is drive?
                                                 (progn 
                                                     (conf-set 'max-speed (/ speed-sport 3.6))
-                                                    (conf-set 'l-watt-max (/ watt-sport 3.6))
+                                                    (conf-set 'l-watt-max watt-sport)
                                                     (setvar 'speedmode 4) ; to sport
                                                 )
                                                 (if (= speedmode 2) ; is eco?
                                                     (progn
                                                         (conf-set 'max-speed (/ speed-drive 3.6))
-                                                        (conf-set 'l-watt-max (/ watt-drive 3.6))
+                                                        (conf-set 'l-watt-max watt-drive)
                                                         (setvar 'speedmode 1) ; to drive
                                                     )
                                                     (if (= speedmode 4) ; is sport?
                                                         (progn
                                                             (conf-set 'max-speed (/ speed-eco 3.6))
-                                                            (conf-set 'l-watt-max (/ watt-eco 3.6))
+                                                            (conf-set 'l-watt-max watt-eco)
                                                             (setvar 'speedmode 2) ; to eco
                                                         )
                                                     )

--- a/res/Lisp/Examples/m365_dash_adc.lisp
+++ b/res/Lisp/Examples/m365_dash_adc.lisp
@@ -47,7 +47,7 @@
 (define speedmode 4)
 
 (conf-set 'max-speed (/ speed-sport 3.6))
-(conf-set 'l-watt-max (/ watt-sport 3.6))
+(conf-set 'l-watt-max watt-sport)
 
 ; Sound feedback
 
@@ -214,19 +214,19 @@
                                             (if (= speedmode 1) ; is drive?
                                                 (progn 
                                                     (conf-set 'max-speed (/ speed-sport 3.6))
-                                                    (conf-set 'l-watt-max (/ watt-sport 3.6))
+                                                    (conf-set 'l-watt-max watt-sport)
                                                     (setvar 'speedmode 4) ; to sport
                                                 )
                                                 (if (= speedmode 2) ; is eco?
                                                     (progn
                                                         (conf-set 'max-speed (/ speed-drive 3.6))
-                                                        (conf-set 'l-watt-max (/ watt-drive 3.6))
+                                                        (conf-set 'l-watt-max watt-drive)
                                                         (setvar 'speedmode 1) ; to drive
                                                     )
                                                     (if (= speedmode 4) ; is sport?
                                                         (progn
                                                             (conf-set 'max-speed (/ speed-eco 3.6))
-                                                            (conf-set 'l-watt-max (/ watt-eco 3.6))
+                                                            (conf-set 'l-watt-max watt-eco)
                                                             (setvar 'speedmode 2) ; to eco
                                                         )
                                                     )

--- a/res/Lisp/Examples/m365_dash_adc.lisp
+++ b/res/Lisp/Examples/m365_dash_adc.lisp
@@ -175,6 +175,7 @@
     (progn
         ; If you do not have any R470 resistors or it still occours to press buttons randomly, try uncommenting this:
         ;(if (<= (* (get-speed) 3.6) min-speed)
+        ;(progn
             (if (> buttonold (gpio-read 'pin-rx))
                 (progn
                     (setvar 'presses (+ presses 1))
@@ -243,7 +244,7 @@
             )
 
             (setvar 'buttonold (gpio-read 'pin-rx))
-        ;)
+        ;))
         (sleep 0.01)
     )
 )


### PR DESCRIPTION
Features to be added:
- [x] Add speed modes (double tap on button)
- [x] Add lock mode with beeping and braking (double press while braking)
- [x] Add min-speed feature (makes it more secure)
- [x] Add shutdown feature (turn it off by long press and back on by single tap)
- [x] Add battery in idle feature
- [x] Add separate ADC version

Fixes to be done (Probably my own issues because no one else has it):
- [x] ~~Figure out why 0x64 packets are not being read. (on my setup)~~ (Can be ignored due to the fact that we do not have to receive any 0x64 packets to sent our own 0x64 back)
- [x] ~~Figure out why button reading is randomly~~ (can be fixed with 470R resistor between 3.3v and RX)

I have read the CLA Document and I hereby sign the CLA
**I have read the CLA Document and I hereby sign the CLA**