### PR TITLE
Remember filepaths for param parser & Configuration XML across instances

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -531,6 +531,8 @@ MainWindow::MainWindow(QWidget *parent) :
         }
     }
 
+    LastParamParserCPath = (mSettings.value("mainwindow/LastParamParserCPath", "./confgenerator").toString());
+
     updateMotortype();
     updateAppToUse();
 
@@ -545,6 +547,7 @@ MainWindow::~MainWindow()
     mSettings.setValue("introVersion", VT_INTRO_VERSION);
     mSettings.setValue("mainwindow/position", pos());
     mSettings.setValue("mainwindow/maximized", isMaximized());
+    mSettings.setValue("mainwindow/LastParamParserCPath", LastParamParserCPath);
 
     if (!isMaximized()) {
         mSettings.setValue("mainwindow/size", size());
@@ -1897,7 +1900,7 @@ void MainWindow::on_actionExportConfigurationParser_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the parser C source and header file"),
-                                        ".",
+                                        LastParamParserCPath,
                                         tr("C Source/Header files (*.c *.h)"));
 
     if (path.isNull()) {
@@ -1905,6 +1908,7 @@ void MainWindow::on_actionExportConfigurationParser_triggered()
     }
 
     Utility::createParamParserC(mVesc, path);
+    LastParamParserCPath = path;
 }
 
 void MainWindow::on_actionBackupConfiguration_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -531,9 +531,9 @@ MainWindow::MainWindow(QWidget *parent) :
         }
     }
 
-    LastParamParserCPath = (mSettings.value("mainwindow/LastParamParserCPath", "./confgenerator").toString());
-    LastMCConfigXMLPath  = (mSettings.value("mainwindow/LastMCConfigXMLPath", "./vesc_mcconf").toString());
-    LastAppConfigXMLPath = (mSettings.value("mainwindow/LastAppConfigXMLPath", "./vesc_appconf").toString());
+    mLastParamParserCPath = (mSettings.value("mainwindow/mLastParamParserCPath", "./confgenerator").toString());
+    mLastMCConfigXMLPath  = (mSettings.value("mainwindow/mLastMCConfigXMLPath", "./vesc_mcconf").toString());
+    mLastAppConfigXMLPath = (mSettings.value("mainwindow/mLastAppConfigXMLPath", "./vesc_appconf").toString());
 
     updateMotortype();
     updateAppToUse();
@@ -549,9 +549,9 @@ MainWindow::~MainWindow()
     mSettings.setValue("introVersion", VT_INTRO_VERSION);
     mSettings.setValue("mainwindow/position", pos());
     mSettings.setValue("mainwindow/maximized", isMaximized());
-    mSettings.setValue("mainwindow/LastParamParserCPath", LastParamParserCPath);
-    mSettings.setValue("mainwindow/LastMCConfigXMLPath", LastMCConfigXMLPath);
-    mSettings.setValue("mainwindow/LastAppConfigXMLPath", LastAppConfigXMLPath);
+    mSettings.setValue("mainwindow/mLastParamParserCPath", mLastParamParserCPath);
+    mSettings.setValue("mainwindow/mLastMCConfigXMLPath", mLastMCConfigXMLPath);
+    mSettings.setValue("mainwindow/mLastAppConfigXMLPath", mLastAppConfigXMLPath);
 
     if (!isMaximized()) {
         mSettings.setValue("mainwindow/size", size());
@@ -1047,7 +1047,7 @@ void MainWindow::on_actionSaveMotorConfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the motor configuration XML file"),
-                                        LastMCConfigXMLPath,
+                                        mLastMCConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1062,7 +1062,7 @@ void MainWindow::on_actionSaveMotorConfXml_triggered()
 
     if (res) {
         showStatusInfo("Saved motor configuration", true);
-        LastMCConfigXMLPath = path;
+        mLastMCConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Save motor configuration"),
                           tr("Could not save motor configuration:<BR>"
@@ -1076,7 +1076,7 @@ void MainWindow::on_actionLoadMotorConfXml_triggered()
     QString path;
     path = QFileDialog::getOpenFileName(this,
                                         tr("Choose motor configuration file to load"),
-                                        LastMCConfigXMLPath,
+                                        mLastMCConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1087,7 +1087,7 @@ void MainWindow::on_actionLoadMotorConfXml_triggered()
 
     if (res) {
         showStatusInfo("Loaded motor configuration", true);
-        LastMCConfigXMLPath = path;
+        mLastMCConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Load motor configuration"),
                           tr("Could not load motor configuration:<BR>"
@@ -1101,7 +1101,7 @@ void MainWindow::on_actionSaveAppconfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the app configuration XML file"),
-                                        LastAppConfigXMLPath,
+                                        mLastAppConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1116,7 +1116,7 @@ void MainWindow::on_actionSaveAppconfXml_triggered()
 
     if (res) {
         showStatusInfo("Saved app configuration", true);
-        LastAppConfigXMLPath = path;
+        mLastAppConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Save app configuration"),
                           tr("Could not save app configuration:<BR>"
@@ -1130,7 +1130,7 @@ void MainWindow::on_actionLoadAppconfXml_triggered()
     QString path;
     path = QFileDialog::getOpenFileName(this,
                                         tr("Choose app configuration file to load"),
-                                        LastAppConfigXMLPath,
+                                        mLastAppConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1141,7 +1141,7 @@ void MainWindow::on_actionLoadAppconfXml_triggered()
 
     if (res) {
         showStatusInfo("Loaded app configuration", true);
-        LastAppConfigXMLPath = path;
+        mLastAppConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Load app configuration"),
                           tr("Could not load app configuration:<BR>"
@@ -1908,7 +1908,7 @@ void MainWindow::on_actionExportConfigurationParser_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the parser C source and header file"),
-                                        LastParamParserCPath,
+                                        mLastParamParserCPath,
                                         tr("C Source/Header files (*.c *.h)"));
 
     if (path.isNull()) {
@@ -1916,7 +1916,7 @@ void MainWindow::on_actionExportConfigurationParser_triggered()
     }
 
     Utility::createParamParserC(mVesc, path);
-    LastParamParserCPath = path;
+    mLastParamParserCPath = path;
 }
 
 void MainWindow::on_actionBackupConfiguration_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1043,7 +1043,7 @@ void MainWindow::on_actionSaveMotorConfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the motor configuration XML file"),
-                                        ".",
+                                        "./vesc_mcconf",
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1095,7 +1095,7 @@ void MainWindow::on_actionSaveAppconfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the app configuration XML file"),
-                                        ".",
+                                        "./vesc_appconf",
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1227,7 +1227,7 @@ void MainWindow::saveParamFileDialog(QString conf, bool wrapIfdef)
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the configuration header file"),
-                                        ".",
+                                        QString("./%1_default").arg(conf.toLower()),
                                         tr("h files (*.h)"));
 
     if (path.isNull()) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -532,6 +532,8 @@ MainWindow::MainWindow(QWidget *parent) :
     }
 
     LastParamParserCPath = (mSettings.value("mainwindow/LastParamParserCPath", "./confgenerator").toString());
+    LastMCConfigXMLPath  = (mSettings.value("mainwindow/LastMCConfigXMLPath", "./vesc_mcconf").toString());
+    LastAppConfigXMLPath = (mSettings.value("mainwindow/LastAppConfigXMLPath", "./vesc_appconf").toString());
 
     updateMotortype();
     updateAppToUse();
@@ -548,6 +550,8 @@ MainWindow::~MainWindow()
     mSettings.setValue("mainwindow/position", pos());
     mSettings.setValue("mainwindow/maximized", isMaximized());
     mSettings.setValue("mainwindow/LastParamParserCPath", LastParamParserCPath);
+    mSettings.setValue("mainwindow/LastMCConfigXMLPath", LastMCConfigXMLPath);
+    mSettings.setValue("mainwindow/LastAppConfigXMLPath", LastAppConfigXMLPath);
 
     if (!isMaximized()) {
         mSettings.setValue("mainwindow/size", size());
@@ -1043,7 +1047,7 @@ void MainWindow::on_actionSaveMotorConfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the motor configuration XML file"),
-                                        "./vesc_mcconf",
+                                        LastMCConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1058,6 +1062,7 @@ void MainWindow::on_actionSaveMotorConfXml_triggered()
 
     if (res) {
         showStatusInfo("Saved motor configuration", true);
+        LastMCConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Save motor configuration"),
                           tr("Could not save motor configuration:<BR>"
@@ -1071,7 +1076,7 @@ void MainWindow::on_actionLoadMotorConfXml_triggered()
     QString path;
     path = QFileDialog::getOpenFileName(this,
                                         tr("Choose motor configuration file to load"),
-                                        ".",
+                                        LastMCConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1082,6 +1087,7 @@ void MainWindow::on_actionLoadMotorConfXml_triggered()
 
     if (res) {
         showStatusInfo("Loaded motor configuration", true);
+        LastMCConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Load motor configuration"),
                           tr("Could not load motor configuration:<BR>"
@@ -1095,7 +1101,7 @@ void MainWindow::on_actionSaveAppconfXml_triggered()
     QString path;
     path = QFileDialog::getSaveFileName(this,
                                         tr("Choose where to save the app configuration XML file"),
-                                        "./vesc_appconf",
+                                        LastAppConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1110,6 +1116,7 @@ void MainWindow::on_actionSaveAppconfXml_triggered()
 
     if (res) {
         showStatusInfo("Saved app configuration", true);
+        LastAppConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Save app configuration"),
                           tr("Could not save app configuration:<BR>"
@@ -1123,7 +1130,7 @@ void MainWindow::on_actionLoadAppconfXml_triggered()
     QString path;
     path = QFileDialog::getOpenFileName(this,
                                         tr("Choose app configuration file to load"),
-                                        ".",
+                                        LastAppConfigXMLPath,
                                         tr("Xml files (*.xml)"));
 
     if (path.isNull()) {
@@ -1134,6 +1141,7 @@ void MainWindow::on_actionLoadAppconfXml_triggered()
 
     if (res) {
         showStatusInfo("Loaded app configuration", true);
+        LastAppConfigXMLPath = path;
     } else {
         showMessageDialog(tr("Load app configuration"),
                           tr("Could not load app configuration:<BR>"

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -169,6 +169,7 @@ private:
     bool mMcConfRead;
     bool mAppConfRead;
     QMap<QString, int> mPageNameIdList;
+    QString LastParamParserCPath;
 
     QTimer mPollRtTimer;
     QTimer mPollAppTimer;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -170,6 +170,8 @@ private:
     bool mAppConfRead;
     QMap<QString, int> mPageNameIdList;
     QString LastParamParserCPath;
+    QString LastMCConfigXMLPath;
+    QString LastAppConfigXMLPath;
 
     QTimer mPollRtTimer;
     QTimer mPollAppTimer;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -169,9 +169,9 @@ private:
     bool mMcConfRead;
     bool mAppConfRead;
     QMap<QString, int> mPageNameIdList;
-    QString LastParamParserCPath;
-    QString LastMCConfigXMLPath;
-    QString LastAppConfigXMLPath;
+    QString mLastParamParserCPath;
+    QString mLastMCConfigXMLPath;
+    QString mLastAppConfigXMLPath;
 
     QTimer mPollRtTimer;
     QTimer mPollAppTimer;


### PR DESCRIPTION
Makes vesc tool remember "Developer -> Export Configuration Parser" filepath across instances instead of defaulting to vesc tool root.

Also remembers filepath for "File -> Save XXX Configuration XML as ..." file options. 