### PR TITLE
Add Tle5012 mcconf options and description

### DIFF
--- a/res/config/6.00/parameters_mcconf.xml
+++ b/res/config/6.00/parameters_mcconf.xml
@@ -3502,7 +3502,11 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A magnetic encoder using a high speed SPI communication. Provides absolute position from start. It has to be connected to a hardware-based SPI peripheral.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;BISSC Encoder&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This encoder uses  RS422, so it has to be connected to the COMM port for high speed communication. A RS422-transceiver such as the MAX490 is required, where CLK and MISO are used as clock and data input lines. To use this encoder, you have to make sure that no app uses UART or ADC1. The ABI resolution field is used to set the BISSC encoder accuracy: 2^(BissC Resolution)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This encoder uses  RS422, so it has to be connected to the COMM port for high speed communication. A RS422-transceiver such as the MAX490 is required, where CLK and MISO are used as clock and data input lines. To use this encoder, you have to make sure that no app uses UART or ADC1. The ABI resolution field is used to set the BISSC encoder accuracy: 2^(BissC Resolution)&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;TLE5104 Encoder&lt;/span&gt; &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A magnetic encoder using the bidirectional SSC protocol. Provides absolute position from start and error protected communication. Currently both “SSC SW” and “SSC HW” use software bitbanging. “SSC SW” uses the hall connector pins which must not have filters. “SSC HW” uses the 7-8 pin adc/uart connector. Recommend 5v sensor power.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Wires must be shielded and/or run together or you will get communication errors.&lt;br /&gt;&lt;br /&gt;“SSC SW” Connections: H1 = SCK, H2 = DATA , H3 = CS &lt;br /&gt;“SSC HW” Connections: ADC1 = SCK, TX = DATA , NSS = CS &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
             <cDefine>MCCONF_M_SENSOR_PORT_MODE</cDefine>
             <valInt>0</valInt>
             <enumNames>Hall Sensors</enumNames>
@@ -3515,6 +3519,8 @@ p, li { white-space: pre-wrap; }
             <enumNames>MT6816 Encoder (SPI)</enumNames>
             <enumNames>AS5X47U Encoder (SPI)</enumNames>
             <enumNames>BISSC Encoder (SPI)</enumNames>
+            <enumNames>TLE5012 Encoder (SSC SW)</enumNames>
+            <enumNames>TLE5012 Encoder (SSC HW)</enumNames>
         </m_sensor_port_mode>
         <m_invert_direction>
             <longName>Invert Motor Direction</longName>


### PR DESCRIPTION
Vesc tool support for https://github.com/vedderb/bldc/pull/551

Help description:

TLE5104 Encoder 
A magnetic encoder using the bidirectional SSC protocol. Provides absolute position from start and error protected communication. Currently both “SSC SW” and “SSC HW” use software bitbanging. “SSC SW” uses the hall connector pins which must not have filters. “SSC HW” uses the 7-8 pin adc/uart connector. Recommend 5v sensor power.
Wires must be shielded and/or run together or you will get communication errors.

“SSC SW” Connections: H1 = SCK, H2 = DATA , H3 = CS 
“SSC HW” Connections: ADC1 = SCK, TX = DATA , NSS = CS 
