### PR TITLE
VESC Packages UI: Matching labels for installing a package

### DIFF
--- a/pages/pagevescpackage.ui
+++ b/pages/pagevescpackage.ui
@@ -116,7 +116,10 @@
            <item>
             <widget class="QPushButton" name="installButton">
              <property name="text">
-              <string>Install</string>
+              <string>Install to VESC</string>
+             </property>
+             <property name="toolTip">
+              <string>Uninstall current package and install the selected package to the connected VESC</string>
              </property>
             </widget>
            </item>
@@ -189,11 +192,14 @@
           <item>
            <widget class="QPushButton" name="writeButton">
             <property name="text">
-             <string>Write to VESC</string>
+             <string>Install to VESC</string>
             </property>
             <property name="icon">
              <iconset resource="../res.qrc">
               <normaloff>:/res/icons/Download-96.png</normaloff>:/res/icons/Download-96.png</iconset>
+            </property>
+            <property name="toolTip">
+             <string>Uninstall current package and install the selected package to the connected VESC</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Installing a package from the package store or from a local file performs the same operation. This is an attempt at making it more clear for the user.

Signed-off-by: Dado Mista <dadomista@gmail.com>