### PR TITLE
Allow the input wizard to run on old firmware

### DIFF
--- a/setupwizardapp.cpp
+++ b/setupwizardapp.cpp
@@ -100,7 +100,7 @@ AppIntroPage::AppIntroPage(VescInterface *vesc, QWidget *parent)
 int AppIntroPage::nextId() const
 {
     if (mVesc->isPortConnected()) {
-        if (mVesc->commands()->isLimitedMode() || !mResetInputOk) {
+        if (mVesc->commands()->isLimitedMode() && !mVesc->commands()->getLimitedCompatibilityCommands().contains(int(COMM_GET_APPCONF)) || !mResetInputOk) {
             return SetupWizardApp::Page_Firmware;
         } else {
             if (mVesc->getCanDevsLast().size() == 0) {
@@ -174,8 +174,7 @@ AppConnectionPage::AppConnectionPage(VescInterface *vesc, QWidget *parent)
 
 int AppConnectionPage::nextId() const
 {
-    if (mVesc->commands()->isLimitedMode() &&
-            !mVesc->commands()->getLimitedCompatibilityCommands().contains(int(COMM_GET_APPCONF))) {
+    if (mVesc->commands()->isLimitedMode()) {
         return SetupWizardApp::Page_Firmware;
     } else {
         return SetupWizardApp::Page_Multi;


### PR DESCRIPTION
This addresses issue #286

I tested this change by compiling a new VESC tool and loaded firmware 5.02 onto a VESC 6

Old firmware warning still shows (OK)
![2022-12-14 13_50_22-VESC Tool](https://user-images.githubusercontent.com/628881/207700404-6bae2cda-b119-4a68-b07e-c234596d4e7e.png)

Firmware is 5.02 (OK)
![2022-12-14 13_50_30-VESC Tool](https://user-images.githubusercontent.com/628881/207700411-7e200687-6769-464b-adf7-68b424590139.png)

VESC tool is 6.02 (OK - fresh compile)
![2022-12-14 13_50_43-VESC Tool](https://user-images.githubusercontent.com/628881/207700409-ff7f69c4-6a37-4572-b8ab-97fa32654f07.png)

Input wizard now goes to the correct page, and no longer shows the old "Your VESC (or one of the VESCs on the CAN-bus) has old firmware" error. (OK)
![2022-12-14 13_51_00-VESC Tool](https://user-images.githubusercontent.com/628881/207700408-1b09ddd9-e92f-4471-b64e-437a0c73f530.png)