### PR TITLE
IMU Wizard: "Close" instead of "Cancel"

### DIFF
--- a/mobile/SetupWizardIMU.qml
+++ b/mobile/SetupWizardIMU.qml
@@ -952,7 +952,7 @@ Item {
                 id: prevButton
                 Layout.fillWidth: true
                 Layout.preferredWidth: 500
-                text: "Cancel"
+                text: (stackLayout.currentIndex != 0) ? "Cancel" : "Close"
                 flat: true
 
                 onClicked: {


### PR DESCRIPTION
To exit the wizard there's only one button available. Nothing is cancelled/aborted when the button is pressed so "Close" is the more appropriate label.

Because the same button is used in different contexts, the label text is now conditional.