### PR TITLE
lzokay: Include <iterator> explicitly for building on gcc12 & clang13

### DIFF
--- a/lzokay/lzokay.cpp
+++ b/lzokay/lzokay.cpp
@@ -1,6 +1,7 @@
 #include "lzokay.hpp"
 #include <cstring>
 #include <algorithm>
+#include <iterator>
 
 /*
  * Based on documentation from the Linux sources: Documentation/lzo.txt


### PR DESCRIPTION
Related: https://github.com/jackoalan/lzokay/pull/7