### PR TITLE
Fail with an error message when lisp import processing fails in CLI mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -854,6 +854,11 @@ int main(int argc, char *argv[])
 
             QFileInfo fi(f);
             pkg.lispData = loader.lispPackImports(f.readAll(), fi.canonicalPath());
+            // Empty array means an error. Otherwise, CodeLoader.lispPackImports() always returns data.
+            if (pkg.lispData.isEmpty()) {
+                qWarning() << "Errors when processing lisp imports.";
+                return 1;
+            }
             f.close();
 
             qDebug() << "Read lisp script done";

--- a/main.cpp
+++ b/main.cpp
@@ -839,12 +839,6 @@ int main(int argc, char *argv[])
             qDebug() << "Opened package" << pkg.name;
         }
 
-        QFile file(pkgPath);
-        if (!file.open(QIODevice::WriteOnly)) {
-            qWarning() << QString("Could not open %1 for writing.").arg(pkgPath);
-            return 1;
-        }
-
         if (!lispPath.isEmpty()) {
             QFile f(lispPath);
             if (!f.open(QIODevice::ReadOnly)) {
@@ -876,6 +870,12 @@ int main(int argc, char *argv[])
             f.close();
 
             qDebug() << "Read qml script done";
+        }
+
+        QFile file(pkgPath);
+        if (!file.open(QIODevice::WriteOnly)) {
+            qWarning() << QString("Could not open %1 for writing.").arg(pkgPath);
+            return 1;
         }
 
         file.write(loader.packVescPackage(pkg));


### PR DESCRIPTION
Returns a non-zero exit code and prints an error message.

Example output:
```
"Append Imports" : "Line: 2: Imported file not found: </path/to/import>. If you are importing from a package in the git repository you might need to update the package archive. That can be done from the the VESC Packages page."
Errors when processing lisp imports.
```

The printed message is quite confusing. I think it refers to the old way the packages were built in `vesc_pkg`, where there were binaries committed in git and some parts were being pulled out of them. That mechanism was also very confusing to me and I would venture to say the concept is just bad (I can elaborate if needed). Unless that mechanism has a good use case, maybe the functionality could be removed altogether and the above error message simplified. Just a suggestion...