### PR TITLE
Package loading fixes

### DIFF
--- a/codeloader.cpp
+++ b/codeloader.cpp
@@ -779,6 +779,11 @@ VescPackage CodeLoader::unpackVescPackage(QByteArray data)
 
 bool CodeLoader::installVescPackage(VescPackage pkg)
 {
+    if (!pkg.loadOk) {
+        mVesc->emitMessageDialog(tr("Write Package"), tr("Package is not valid."), false);
+        return false;
+    }
+
     bool res = true;
     QByteArray qml;
 

--- a/codeloader.cpp
+++ b/codeloader.cpp
@@ -787,25 +787,31 @@ bool CodeLoader::installVescPackage(VescPackage pkg)
     bool res = true;
     QByteArray qml;
 
-    if (res && !pkg.qmlFile.isEmpty()) {
+    if (!pkg.qmlFile.isEmpty()) {
         qml = qmlCompress(pkg.qmlFile);
         res = qmlErase(qml.size() + 100);
+
+        if (res) {
+            res = qmlUpload(qml, pkg.qmlIsFullscreen);
+        }
+    } else {
+        res = qmlErase(16);
     }
 
-    if (res && !pkg.qmlFile.isEmpty()) {
-        res = qmlUpload(qml, pkg.qmlIsFullscreen);
-    }
+    if (res) {
+        if (!pkg.lispData.isEmpty()) {
+            res = lispErase(pkg.lispData.size() + 100);
 
-    if (res && !pkg.lispData.isEmpty()) {
-        res = lispErase(pkg.lispData.size() + 100);
-    }
+            if (res) {
+                res = lispUpload(VByteArray(pkg.lispData));
 
-    if (res && !pkg.lispData.isEmpty()) {
-        res = lispUpload(VByteArray(pkg.lispData));
-    }
-
-    if (res && !pkg.lispData.isEmpty()) {
-        mVesc->commands()->lispSetRunning(1);
+                if (res) {
+                    mVesc->commands()->lispSetRunning(1);
+                }
+            }
+        } else {
+            res = lispErase(16);
+        }
     }
 
     Utility::sleepWithEventLoop(500);

--- a/pages/pagevescpackage.cpp
+++ b/pages/pagevescpackage.cpp
@@ -235,6 +235,11 @@ void PageVescPackage::on_loadRefreshButton_clicked()
 
     auto pkg = mLoader.unpackVescPackage(f.readAll());
 
+    if (!pkg.loadOk) {
+        mVesc->emitMessageDialog(tr("Open Package"), tr("Package is not valid."), false);
+        return;
+    }
+
     QString line1 = QTextStream(&pkg.description).readLine();
     if (line1.contains("<!DOCTYPE HTML PUBLIC", Qt::CaseInsensitive)) {
         ui->loadBrowser->document()->setHtml(pkg.description);
@@ -269,6 +274,11 @@ void PageVescPackage::on_outputRefreshButton_clicked()
     }
 
     auto pkg = mLoader.unpackVescPackage(f.readAll());
+
+    if (!pkg.loadOk) {
+        mVesc->emitMessageDialog(tr("Open Package"), tr("Package is not valid."), false);
+        return;
+    }
 
     QString line1 = QTextStream(&pkg.description).readLine();
     if (line1.contains("<!DOCTYPE HTML PUBLIC", Qt::CaseInsensitive)) {


### PR DESCRIPTION
Add checks for "validity" of a package when it's being opened, validity here being the package name could be read from the binary format. Without the check, vesc_tool would happily work with zero-size file.

When writing the package, always erase both qml and lisp. If we don't erase, the old code will stay in place and keep loading for a possibly completely different package.