### PR TITLE
Improve and unify config reading and writing messages

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -399,15 +399,15 @@ void Commands::processPacket(QByteArray data)
         break;
 
     case COMM_SET_MCCONF:
-        emit ackReceived("MCCONF Write OK");
+        emit ackReceived("Motor config write OK");
         break;
 
     case COMM_SET_APPCONF:
-        emit ackReceived("APPCONF Write OK");
+        emit ackReceived("App config write OK");
         break;
 
     case COMM_SET_APPCONF_NO_STORE:
-        emit ackReceived("APPCONF_NO_STORE Write OK");
+        emit ackReceived("App config set OK");
         break;
 
     case COMM_CUSTOM_APP_DATA:

--- a/commands.cpp
+++ b/commands.cpp
@@ -731,9 +731,10 @@ void Commands::processPacket(QByteArray data)
         emit bmsValuesRx(val);
     } break;
 
-    case COMM_SET_CUSTOM_CONFIG:
-        emit ackReceived("COMM_SET_CUSTOM_CONFIG Write OK");
-        break;
+    case COMM_SET_CUSTOM_CONFIG: {
+        int confId = vb.vbPopFrontUint8();
+        emit ackReceived(tr("Custom config %1 write OK").arg(confId));
+    } break;
 
     case COMM_GET_CUSTOM_CONFIG:
     case COMM_GET_CUSTOM_CONFIG_DEFAULT: {

--- a/commands.cpp
+++ b/commands.cpp
@@ -733,7 +733,7 @@ void Commands::processPacket(QByteArray data)
 
     case COMM_SET_CUSTOM_CONFIG: {
         int confId = vb.vbPopFrontUint8();
-        emit ackReceived(tr("Custom config %1 write OK").arg(confId));
+        emit customConfigAckReceived(confId);
     } break;
 
     case COMM_GET_CUSTOM_CONFIG:

--- a/commands.h
+++ b/commands.h
@@ -135,6 +135,7 @@ signals:
     void bmsValuesRx(BMS_VALUES val);
     void customConfigChunkRx(int confInd, int lenConf, int ofsConf, QByteArray data);
     void customConfigRx(int confInd, QByteArray data);
+    void customConfigAckReceived(int confId);
     void pswStatusRx(PSW_STATUS stat);
     void qmluiHwRx(int lenQml, int ofsQml, QByteArray data);
     void qmluiAppRx(int lenQml, int ofsQml, QByteArray data);

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -3951,12 +3951,12 @@ void VescInterface::fwVersionReceived(FW_RX_PARAMS params)
 
 void VescInterface::appconfUpdated()
 {
-    emit statusMessage(tr("App configuration updated"), true);
+    emit statusMessage(tr("App config updated"), true);
 }
 
 void VescInterface::mcconfUpdated()
 {
-    emit statusMessage(tr("MC configuration updated"), true);
+    emit statusMessage(tr("Motor config updated"), true);
 
     if (isPortConnected() && fwRx()) {
         QPair<int, int> fw_connected = qMakePair(mLastFwParams.major, mLastFwParams.minor);
@@ -4305,17 +4305,17 @@ bool VescInterface::confRestoreBackup(bool can)
 
                 if (!txMc) {
                     emitMessageDialog("Restore Configuration",
-                                      "No response when writing MC configuration to " + uuid + ".", false, false);
+                                      "No response when writing Motor config to " + uuid + ".", false, false);
                 }
 
                 if (!txApp) {
                     emitMessageDialog("Restore Configuration",
-                                      "No response when writing app configuration to " + uuid + ".", false, false);
+                                      "No response when writing App config to " + uuid + ".", false, false);
                 }
 
                 if (!txCustom) {
                     emitMessageDialog("Restore Configuration",
-                                      "No response when writing" + pCustom->getParam("hw_name")->longName + "configuration to " + uuid + ".", false, false);
+                                      "No response when writing " + pCustom->getParam("hw_name")->longName + " configuration to " + uuid + ".", false, false);
                 }
 
                 return txMc && txApp;


### PR DESCRIPTION
It's the little things that make the UI experience better for users.

Not sure you'll like the last commit, using the hw_name of the custom config (especially since I had to add a signal for it), but it's already used in couple of places and I think it looks much better.