### PR TITLE
Add a Reload and Run button to the QML editor page

### DIFF
--- a/pages/pagescripting.cpp
+++ b/pages/pagescripting.cpp
@@ -242,6 +242,25 @@ void PageScripting::on_stopButton_clicked()
     mQmlUi.stopCustomGui();
 }
 
+void PageScripting::on_reloadAndRunButton_clicked()
+{
+    QFile file(ui->mainEdit->fileNow());
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::critical(this, "Open QML File",
+                              "Could not open example for reading");
+        return;
+    }
+
+    ui->mainEdit->codeEditor()->setPlainText(file.readAll());
+
+    file.close();
+
+    ui->qmlWidget->setSource(QUrl(QLatin1String("qrc:/res/qml/DynamicLoader.qml")));
+    ui->qmlWidget->engine()->clearComponentCache();
+    emit reloadQml(qmlToRun());
+}
+
 void PageScripting::on_runWindowButton_clicked()
 {
     ui->runWindowButton->setEnabled(false);

--- a/pages/pagescripting.h
+++ b/pages/pagescripting.h
@@ -55,6 +55,7 @@ public slots:
 private slots:
     void on_runButton_clicked();
     void on_stopButton_clicked();
+    void on_reloadAndRunButton_clicked();
     void on_runWindowButton_clicked();
     void on_fullscreenButton_clicked();
     void on_openRecentButton_clicked();

--- a/pages/pagescripting.ui
+++ b/pages/pagescripting.ui
@@ -54,6 +54,20 @@
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="reloadAndRunButton">
+            <property name="text">
+             <string>Reload and Run</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../res.qrc">
+              <normaloff>:/res/icons/Circled Play-96.png</normaloff>:/res/icons/Circled Play-96.png</iconset>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="runWindowButton">
             <property name="text">
              <string>Run in Window</string>


### PR DESCRIPTION
When using an external editor, it's a lot of clicks to reload and run the file. Adds a button to do everything in one click.

Not sure you'll want this, I added the button to make my life easier, feel free to close if unwanted.