### PR TITLE
Increase MD5 timeout during verify

### DIFF
--- a/esp32/esp_loader.c
+++ b/esp32/esp_loader.c
@@ -43,7 +43,7 @@ static uint32_t s_flash_write_size = 0;
 static const target_registers_t *s_reg = NULL;
 static target_chip_t s_target = ESP_UNKNOWN_CHIP;
 
-static const uint32_t MD5_TIMEOUT_PER_MB = 1200;
+static const uint32_t MD5_TIMEOUT_PER_MB = 12000;
 static struct MD5Context s_md5_context;
 static uint32_t s_start_address;
 static uint32_t s_image_size;


### PR DESCRIPTION
I use the ESP Programmer tool often and was growing accustomed to the `MD5 Timeout, but probably OK` message. Recalling a similar issue I had with a custom ESP flash utility, I increased the MD5 verify timeout to match that of a flash erase operation. Now I might have to get used to seeing `Flash verified`