### PR TITLE
can bus, fixed writing failure on large frame

### DIFF
--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -3385,7 +3385,7 @@ void VescInterface::packetDataToSend(QByteArray &data)
 
                 mCanDevice->writeFrame(frame);
                 mCanDevice->waitForFramesWritten(5);
-//                QThread::msleep(5);
+                QThread::msleep(1);
                 payload.clear();
             }
 


### PR DESCRIPTION
I am able to use can bus without problem by `DEFINES += HAS_CANBUS`.  However, when I try to write config or firmware it always lost connection with vesc hardware. I found this PR https://github.com/vedderb/vesc_tool/pull/43 and fixed the problem by following it.