### PR TITLE
Add getHardwareNow and getHardwareTypeNow

### DIFF
--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -666,6 +666,24 @@ QPair<int, int> VescInterface::getFirmwareNowPair()
     return mFwPair;
 }
 
+QString VescInterface::getHardwareNow()
+{
+    return mHwTxt;
+}
+
+QString VescInterface::getHardwareTypeNow()
+{
+    switch (mHwType){
+    case HW_TYPE_VESC:
+        return "VESC";
+    case HW_TYPE_VESC_BMS:
+        return "VESC BMS";
+    case HW_TYPE_CUSTOM_MODULE:
+        return "Custom Module";
+    }
+    return "Unknown";
+}
+
 void VescInterface::emitStatusMessage(const QString &msg, bool isGood)
 {
     emit statusMessage(msg, isGood);
@@ -3832,6 +3850,7 @@ void VescInterface::fwVersionReceived(FW_RX_PARAMS params)
         mFwTxt = QString("Fw: %1.%2").arg(params.major).arg(params.minor);
         mFwPair = qMakePair(params.major, params.minor);
         mHwTxt = params.hw;
+        mHwType = params.hwType;
         if (!params.hw.isEmpty()) {
             mFwTxt += ", Hw: " + params.hw;
         }

--- a/vescinterface.h
+++ b/vescinterface.h
@@ -81,6 +81,8 @@ public:
     Q_INVOKABLE void emitStatusMessage(const QString &msg, bool isGood);
     Q_INVOKABLE void emitMessageDialog(const QString &title, const QString &msg, bool isGood, bool richText = false);
     Q_INVOKABLE bool fwRx();
+    Q_INVOKABLE QString getHardwareNow();
+    Q_INVOKABLE QString getHardwareTypeNow();
     Q_INVOKABLE void storeSettings();
 
     // Profiles
@@ -379,6 +381,7 @@ private:
     QString mFwTxt;
     QPair<int, int> mFwPair;
     QString mHwTxt;
+    HW_TYPE mHwType;
     QString mUuidStr;
     QString mUuidStrLocal;
     bool mIsUploadingFw;


### PR DESCRIPTION
This allows getting hardware name and type from QML

Example code:

```qml
import QtQuick 2.7
import QtQuick.Controls 2.0

import Vedder.vesc.vescinterface 1.0

Item {
    function testHw(){
       console.log( VescIf.getHardwareNow());
       console.log( VescIf.getHardwareTypeNow());
    }

    Button{
        text :"Test HW"
        onClicked: testHw()
    }
}
```