### PR TITLE
Config serialization eror handling and adding serialized data length

### DIFF
--- a/configparams.cpp
+++ b/configparams.cpp
@@ -1536,6 +1536,7 @@ bool ConfigParams::saveCDefines(const QString &fileName, bool wrapIfdef)
         return false;
     }
 
+    bool ok = true;
     QTextStream out(&file);
     QFileInfo info(file);
     QString nameStr = info.fileName().toUpper().replace(".", "_") + "_";
@@ -1575,6 +1576,7 @@ bool ConfigParams::saveCDefines(const QString &fileName, bool wrapIfdef)
 
                 default:
                     qWarning() << name << ": type not supported.";
+                    ok = false;
                     break;
                 }
 
@@ -1586,6 +1588,7 @@ bool ConfigParams::saveCDefines(const QString &fileName, bool wrapIfdef)
             }
         } else {
             qWarning() << name << "not found.";
+            ok = false;
         }
     }
 
@@ -1595,7 +1598,7 @@ bool ConfigParams::saveCDefines(const QString &fileName, bool wrapIfdef)
     out.flush();
     file.close();
 
-    return true;
+    return ok;
 }
 
 /**

--- a/configparams.cpp
+++ b/configparams.cpp
@@ -1327,6 +1327,7 @@ bool ConfigParams::setParamsXML(QXmlStreamReader &stream)
         }
     }
 
+    bool ok = true;
     if (nameFound) {
         while (stream.readNextStartElement()) {
             QString nameFirst = stream.name().toString();
@@ -1389,12 +1390,14 @@ bool ConfigParams::setParamsXML(QXmlStreamReader &stream)
                             p.vTxDoubleScale = stream.readElementText().toDouble();
                         } else {
                             qWarning() << "Parameter not found: " << name;
+                            ok = false;
                             stream.skipCurrentElement();
                         }
 
                         if (stream.hasError()) {
                             qWarning() << "XML ERROR :" << stream.errorString();
                             qWarning() << stream.lineNumber() << stream.columnNumber();
+                            ok = false;
                         }
                     }
 
@@ -1409,6 +1412,7 @@ bool ConfigParams::setParamsXML(QXmlStreamReader &stream)
                         mSerializeOrder.append(stream.readElementText());
                     } else {
                         qWarning() << "Parameter not found: " << name;
+                        ok = false;
                         stream.skipCurrentElement();
                     }
                 }
@@ -1438,32 +1442,42 @@ bool ConfigParams::setParamsXML(QXmlStreamReader &stream)
                                                 addParamToSubgroup(group, subgroup, stream.readElementText());
                                             } else {
                                                 qWarning() << "Parameter not found: " << name3;
+                                                ok = false;
                                                 stream.skipCurrentElement();
                                             }
                                         }
                                     } else {
                                         qWarning() << "Parameter not found: " << name2;
+                                        ok = false;
                                         stream.skipCurrentElement();
                                     }
                                 }
                             } else {
                                 qWarning() << "Parameter not found: " << name;
+                                ok = false;
                                 stream.skipCurrentElement();
                             }
                         }
                     } else {
                         qWarning() << "Parameter not found: " << name0;
+                        ok = false;
                         stream.skipCurrentElement();
                     }
                 }
             } else {
                 qWarning() << "Parameter not found: " << nameFirst;
+                ok = false;
                 stream.skipCurrentElement();
             }
         }
 
-        mXmlStatus = tr("OK");
-        return true;
+        if (ok && !stream.hasError()) {
+            mXmlStatus = tr("OK");
+            return true;
+        } else {
+            mXmlStatus = tr("Error");
+            return false;
+        }
     } else {
         mXmlStatus = tr("tag <b>%1</b> not found").arg(configName);
         qWarning() << mXmlStatus;

--- a/main.cpp
+++ b/main.cpp
@@ -765,12 +765,18 @@ int main(int argc, char *argv[])
         QString pathParser = xmlCodePath + "confparser.c";
         QString pathCompressed = xmlCodePath + "confxml.c";
 
-        Utility::createCompressedConfigC(&conf, nameConfig, pathCompressed);
-        Utility::createParamParserC(&conf, nameConfig, pathParser);
-        conf.saveCDefines(pathDefines, true);
+        bool ok = true;
+        ok = Utility::createCompressedConfigC(&conf, nameConfig, pathCompressed) && ok;
+        ok = Utility::createParamParserC(&conf, nameConfig, pathParser) && ok;
+        ok = conf.saveCDefines(pathDefines, true) && ok;
 
-        qDebug() << "Done!";
-        return 0;
+        if (ok) {
+            qDebug() << "Done!";
+            return 0;
+        } else {
+            qCritical() << "Errors while generating files.";
+            return 2;
+        }
     }
 
     if (!fwPackIn.isEmpty()) {

--- a/utility.cpp
+++ b/utility.cpp
@@ -1977,7 +1977,7 @@ void Utility::serialFunc(ConfigParams *params, QTextStream &s) {
                     break;
 
                 default:
-                    qWarning() << "Serialization type not supporter";
+                    qWarning() << "Serialization type not supported";
                     break;
                 }
                 break;
@@ -1997,7 +1997,7 @@ void Utility::serialFunc(ConfigParams *params, QTextStream &s) {
                     break;
 
                 default:
-                    qWarning() << "Serialization type not supporter";
+                    qWarning() << "Serialization type not supported";
                     break;
                 }
                 break;
@@ -2070,7 +2070,7 @@ void Utility::deserialFunc(ConfigParams *params, QTextStream &s) {
                     break;
 
                 default:
-                    qWarning() << "Serialization type not supporter";
+                    qWarning() << "Serialization type not supported";
                     break;
                 }
                 break;
@@ -2091,7 +2091,7 @@ void Utility::deserialFunc(ConfigParams *params, QTextStream &s) {
                     break;
 
                 default:
-                    qWarning() << "Serialization type not supporter";
+                    qWarning() << "Serialization type not supported";
                     break;
                 }
                 break;

--- a/utility.h
+++ b/utility.h
@@ -159,6 +159,7 @@ signals:
 public slots:
 
 private:
+    static bool calculateSerializedLength(ConfigParams *params, uint32_t &length);
     static bool serialFunc(ConfigParams *params, QTextStream &s);
     static bool deserialFunc(ConfigParams *params, QTextStream &s);
     static bool defaultFunc(ConfigParams *params, QTextStream &s);

--- a/utility.h
+++ b/utility.h
@@ -159,9 +159,9 @@ signals:
 public slots:
 
 private:
-    static void serialFunc(ConfigParams *params, QTextStream &s);
-    static void deserialFunc(ConfigParams *params, QTextStream &s);
-    static void defaultFunc(ConfigParams *params, QTextStream &s);
+    static bool serialFunc(ConfigParams *params, QTextStream &s);
+    static bool deserialFunc(ConfigParams *params, QTextStream &s);
+    static bool defaultFunc(ConfigParams *params, QTextStream &s);
 
     static QMap<QString,QColor> mAppColors;
     static bool isDark;


### PR DESCRIPTION
I mainly went to add the serialized data length, but thought I'd fix some error handling when touching that part. I can split it off if needed.

The error handling motivation is primarily for the `vesc_tool --xmlConfToCode ...` to fail on errors. Right now it will generate the files even if there are errors and the user will likely not notice in the build output, meaning they find out after some time wasted investigating why the code doesn't work.

Regarding the serialized data length: I changed my package config storing to EEPROM to use the confparser serialization to save space. It works well (and saves over 40%), the only hurdle is there is no information about the size of the buffer needed, and with the current API it's not possible to check if the buffer is long enough. On write, I can recognize it after the fact (random memory was overwritten, very bad), on read I can't tell at all.

I thought it'd be easy to add the size (so that I can allocate the exact size for the buffer), but there are variable length strings in the config. AFAIK these are not supported in Custom Config, so that's one thing. The strings have the `maxLength` attribute, I used it, but looking at how it's handled, it seems it can be 0 too. I haven't entirely found if and when exactly the `maxLength` is enforced, and what's the situation when it's 0. Any advice, what do you think?