### PR TITLE
Config serialization: Error out when generating code for unlimited length strings

### DIFF
--- a/utility.cpp
+++ b/utility.cpp
@@ -1995,6 +1995,12 @@ bool Utility::calculateSerializedLength(ConfigParams *params, uint32_t &length) 
                 break;
 
             case CFG_T_QSTRING:
+                if (p->maxLen == 0) {
+                    qWarning() << "Serializing unlimited (max length 0) strings not supported";
+                    ok = false;
+                    break;
+                }
+
                 length += p->maxLen + 1;
                 break;
 


### PR DESCRIPTION
For unlimited length strings (maxLen = 0) the buffer size can't be calculated, the decision was to not allow them to be serializable.