### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,114 @@
+{
+  "nodes": {
+    "bldcSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733324381,
+        "narHash": "sha256-ui9N8QSog1G5zyK7yRrD0Xl+Y2CZhvvhBkaJuQZ2qZw=",
+        "owner": "vedderb",
+        "repo": "bldc",
+        "rev": "a0d40e2c5a42c810888d8c379307e6b0a118a125",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vedderb",
+        "ref": "release_6_05",
+        "repo": "bldc",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bldcSrc": "bldcSrc",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Packages VESC Tool into a flake.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    bldcSrc = {
+      url = "github:vedderb/bldc/release_6_05";
+      flake = false;
+    };
+  };
+
+  # TODO: Add support for building on/for other systems.
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      treefmt-nix,
+      bldcSrc,
+    }@inputs:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+      in
+      {
+        packages = {
+          inherit (pkgs)
+            vesc-tool
+            vesc-tool-free
+            vesc-tool-copper
+            vesc-tool-bronze
+            vesc-tool-silver
+            vesc-tool-gold
+            vesc-tool-platinum
+            ;
+          bldc-fw = pkgs.callPackage ./pkgs/vesc-tool/bldc-fw.nix { src = bldcSrc; };
+          default = pkgs.vesc-tool;
+        };
+
+        # For `nix fmt`
+        formatter = treefmtEval.config.build.wrapper;
+
+        checks = {
+          # For `nix flake check`
+          formatting = treefmtEval.config.build.check self;
+        };
+      }
+    )
+    // {
+      overlays.default = (nixpkgs.lib.makeOverridable (import ./overlay.nix)) {
+        inherit bldcSrc;
+        src = self;
+      };
+      # For development in the nix repl
+      inherit self;
+    };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,18 @@
+{
+  src,
+  bldcSrc,
+  fwBoards ? [ ],
+}:
+
+final: prev: rec {
+  vesc-tool = prev.callPackage ./pkgs/vesc-tool {
+    inherit src bldcSrc fwBoards;
+    kind = "original";
+  };
+  vesc-tool-platinum = vesc-tool.override { kind = "platinum"; };
+  vesc-tool-gold = vesc-tool.override { kind = "gold"; };
+  vesc-tool-silver = vesc-tool.override { kind = "silver"; };
+  vesc-tool-bronze = vesc-tool.override { kind = "bronze"; };
+  vesc-tool-copper = vesc-tool.override { kind = "copper"; };
+  vesc-tool-free = vesc-tool.override { kind = "free"; };
+}

--- a/pkgs/vesc-tool/bldc-fw.nix
+++ b/pkgs/vesc-tool/bldc-fw.nix
@@ -1,0 +1,59 @@
+# Builds res_fw.qrc in bldc for the specificed fw versions.
+{
+  src,
+  # List of bldc board names to be built, i.e. a list of bldc "fw_*" Makefile
+  # targets without the "fw_" prefix.
+  # Can also be the string "all", which builds all standard board firmwares.
+  fwBoards ? [ ],
+  pkgs,
+}:
+
+let
+  fwTargets =
+    if fwBoards == "all" then
+      [ "all_fw" ]
+    # VESC Tool doesn't build if the provided res_fw.qrc file is empty for some
+    # reason. Therefore always include "general purpose" firmware.
+    else
+      builtins.map (board: "fw_${board}") (fwBoards ++ [ "gp" ]);
+in
+pkgs.stdenv.mkDerivation rec {
+  pname = "bldc-fw";
+  version = src.shortRev or src.dirtyShortRev or "unknown";
+
+  inherit src;
+
+  # dontConfigure = true;
+  dontPatch = true;
+  dontFixup = true;
+
+  buildPhase = ''
+    # Initialize dummy git repo to make package_firmware.py happy.
+    # It doesn't actually use the hash for anything but just queries it for
+    # whatever reason so it doesn't matter if it's not correct. (:
+    git init .
+    git config user.email "nixbld@localhost"
+    git config user.name "nixbld"
+    git commit --allow-empty -m "dummy"
+
+    ${
+      if builtins.length fwTargets != 0 then
+        "make -j $NIX_BUILD_CORES ${builtins.concatStringsSep " " fwTargets}"
+      else
+        ""
+    }
+
+    python package_firmware.py
+  '';
+  installPhase = ''
+    mkdir -p $out
+
+    cp -r ./package/* $out/
+  '';
+
+  nativeBuildInputs = [
+    pkgs.gcc-arm-embedded-7
+    pkgs.python3
+    pkgs.git
+  ];
+}

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -1,0 +1,103 @@
+{
+  src,
+  bldcSrc,
+  # One of "original", "platinum", "gold", "silver", "bronze", or "free"
+  kind ? "free",
+  # List of bldc board names to be built and included, i.e. a list of bldc "fw_*"
+  # Makefile targets without the "fw_" prefix.
+  # Can also be the string "all", which builds all standard board firmwares.
+  fwBoards ? [ ],
+
+  lib,
+  pkgs,
+}:
+
+let
+  firstToUpper =
+    str:
+    (lib.toUpper (builtins.substring 0 1 str)) + (builtins.substring 1 (builtins.stringLength str) str);
+  kindTitleCase = firstToUpper kind;
+  executableName = "vesc_tool${if kind == "original" then "" else "_${kind}"}";
+  iconPath =
+    {
+      "original" = "res/version/neutral_v.svg";
+      "free" = "res/version/free_v.svg";
+      "copper" = "res/version/copper_v.svg";
+      "bronze" = "res/version/bronze_v.svg";
+      "silver" = "res/version/silver_v.svg";
+      "gold" = "res/version/gold_v.svg";
+      "platinum" = "res/version/platinum_v.svg";
+    }
+    .${kind};
+
+  bldc-fw = pkgs.callPackage ./bldc-fw.nix {
+    src = bldcSrc;
+    inherit fwBoards;
+  };
+in
+pkgs.stdenv.mkDerivation {
+  pname = executableName;
+  version = src.shortRev or src.dirtyShortRev or src.rev or src.dirtyRev or "unknown";
+
+  meta = with lib; {
+    description = "VESC Tool ${kind}, an IDE for controlling and configuring VESC-compatible motor controllers and other devices.";
+    platforms = platforms.linux;
+  };
+
+  desktopItems = [
+    (pkgs.makeDesktopItem {
+      name = "com.vesc-project.";
+      exec = executableName;
+      icon = "vesc_tool_${kind}.svg";
+      comment = "IDE for controlling and configuring VESC-compatible motor controllers and other devices.";
+      desktopName = "VESC Tool ${kindTitleCase}";
+      genericName = "Integrated Development Environment";
+      categories = [ "Development" ];
+    })
+  ];
+
+  inherit src;
+
+  configurePhase = ''
+    qmake -config release "CONFIG += release_lin build_${kind}"
+  '';
+  buildPhase = ''
+    mkdir -p ./res/firmwares/
+    cp -r ${bldc-fw}/* ./res/firmwares/
+
+    ls -la res/firmwares
+
+    make -j$NIX_BUILD_CORES
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p \
+      $out/bin \
+      $out/share/icons/hicolor/scalable/apps
+
+    cp build/lin/vesc_tool_* $out/bin/${executableName}
+    cp ${iconPath} $out/share/icons/hicolor/scalable/apps/vesc_tool_${kind}.svg
+    echo $desktopItems
+
+    runHook postInstall
+  '';
+
+  buildInputs = [ pkgs.libsForQt5.qtbase ];
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.libsForQt5.qtbase
+    pkgs.libsForQt5.qtquickcontrols2
+    pkgs.libsForQt5.qtgamepad
+    pkgs.libsForQt5.qtconnectivity
+    pkgs.libsForQt5.qtpositioning
+    pkgs.libsForQt5.qtserialport
+    pkgs.libsForQt5.qtgraphicaleffects
+    pkgs.libsForQt5.wrapQtAppsHook
+
+    # Make the desktop icon work
+    pkgs.copyDesktopItems
+    pkgs.tree
+  ];
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+{
+  # Used to find the project root
+  projectRootFile = "flake.nix";
+
+  programs.nixfmt.enable = true;
+
+  # Files to exclude from formatting.
+  settings.global.excludes = [
+    # Generated files
+    "build/**"
+    "tools/**"
+
+    # Exclude non-Nix code for now.
+    "**/.editorconfig"
+    "**/.gitattributes"
+    "**/.gitignore"
+    "**/.clang-format"
+    "LICENSE"
+    "**/LICENSE"
+    "**/LICENSE.MIT"
+    "**/AUTHORS"
+    "*.c"
+    "*.h"
+    "*.cpp"
+    "*.hpp"
+    "*.ui"
+    "*.qml"
+    "*.pri"
+    "*.qrc"
+    "*.pro"
+    "*.png"
+    "*.jpg"
+    "*.svg"
+    "*.json"
+    "*.bin"
+    "*.ttf"
+    "*.md"
+    "*.xml"
+    "*.lisp"
+    "*.yml"
+    "*.conf"
+    "*.txt"
+    "*.sh"
+    "*.plist"
+    # spell-checker: disable-next-line
+    "qmarkdowntextedit/trans/**"
+    "*.pc.in"
+    "build_*"
+    "*.storyboard"
+    "ios/iTunesArtwork"
+    "ios/iTunesArtwork@2x"
+    "*.mm"
+    "*.icns"
+    "**/HUFFCODE"
+    "QCodeEditor/include/**"
+    "*.in"
+    "*.gradle"
+    "*.java"
+    "*.jar"
+    "*.properties"
+    "**/gradlew"
+    "application/create_app"
+  ];
+}


### PR DESCRIPTION
Adds a Nix flake which outputs all of the different VESC Tool versions.

After it has been merged you will also be able to run `nix run github:vedderb/vesc_tool` from anywhere and get a fresh build of the latest VESC Tool! (Provided that you have `nix` installed.)

I also decided to configure `nix fmt`, which formats the projects files. But I only enabled it for .nix files.
