### PR TITLE
Update flake to nixpkgs 25.05

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ build_android_signed
 
 res/firmwares/*/
 /build
+
+# Nix output
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1748302896,
+        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgsOld": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -72,6 +88,7 @@
         "bldcSrc": "bldcSrc",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgsOld": "nixpkgsOld",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,11 @@
   description = "Packages VESC Tool into a flake.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    # gcc-arm-embedded-7 has been removed from nixpkgs since 25.05 since it's
+    # old and unmaintained. However, this project still uses that version, so we
+    # include an older version of nixpkgs to access it.
+    nixpkgsOld.url = "github:nixos/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     bldcSrc = {
@@ -16,6 +20,7 @@
     {
       self,
       nixpkgs,
+      nixpkgsOld,
       flake-utils,
       treefmt-nix,
       bldcSrc,
@@ -30,6 +35,7 @@
         selfPkgs = import ./pkgs {
           inherit pkgs bldcSrc;
           src = self;
+          gcc-arm-embedded-7 = nixpkgsOld.legacyPackages.${system}.gcc-arm-embedded-7;
         };
       in
       {
@@ -48,7 +54,7 @@
     )
     // {
       overlays.default = (nixpkgs.lib.makeOverridable (import ./overlay.nix)) {
-        inherit bldcSrc;
+        inherit bldcSrc nixpkgsOld;
         src = self;
       };
       # For development in the nix repl

--- a/overlay.nix
+++ b/overlay.nix
@@ -2,10 +2,12 @@
   src,
   bldcSrc,
   fwBoards ? [ ],
+  nixpkgsOld,
 }:
 
 final: prev:
 import ./pkgs {
   inherit src bldcSrc fwBoards;
   pkgs = prev;
+  gcc-arm-embedded-7 = nixpkgsOld.legacyPackages.${prev.system}.gcc-arm-embedded-7;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,10 +3,17 @@
   src,
   bldcSrc,
   fwBoards ? [ ],
+
+  gcc-arm-embedded-7,
 }:
 rec {
   vesc-tool = pkgs.callPackage ./vesc-tool {
-    inherit src bldcSrc fwBoards;
+    inherit
+      src
+      bldcSrc
+      fwBoards
+      gcc-arm-embedded-7
+      ;
     kind = "original";
   };
   vesc-tool-platinum = vesc-tool.override { kind = "platinum"; };
@@ -17,7 +24,7 @@ rec {
   vesc-tool-free = vesc-tool.override { kind = "free"; };
 
   bldc-fw = pkgs.callPackage ./vesc-tool/bldc-fw.nix {
-    inherit fwBoards;
+    inherit fwBoards gcc-arm-embedded-7;
     src = bldcSrc;
   };
 }

--- a/pkgs/vesc-tool/bldc-fw.nix
+++ b/pkgs/vesc-tool/bldc-fw.nix
@@ -5,7 +5,11 @@
   # targets without the "fw_" prefix.
   # Can also be the string "all", which builds all standard board firmwares.
   fwBoards ? [ ],
-  pkgs,
+
+  gcc-arm-embedded-7,
+  git,
+  python3,
+  stdenv,
 }:
 
 let
@@ -17,7 +21,7 @@ let
     else
       builtins.map (board: "fw_${board}") (fwBoards ++ [ "gp" ]);
 in
-pkgs.stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "bldc-fw";
   version = src.shortRev or src.dirtyShortRev or "unknown";
 
@@ -52,8 +56,8 @@ pkgs.stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    pkgs.gcc-arm-embedded-7
-    pkgs.python3
-    pkgs.git
+    gcc-arm-embedded-7
+    python3
+    git
   ];
 }

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -9,7 +9,14 @@
   fwBoards ? [ ],
 
   lib,
-  pkgs,
+  callPackage,
+  cmake,
+  copyDesktopItems,
+  gcc-arm-embedded-7,
+  libsForQt5,
+  makeDesktopItem,
+  stdenv,
+  tree,
 }:
 
 let
@@ -30,12 +37,12 @@ let
     }
     .${kind};
 
-  bldc-fw = pkgs.callPackage ./bldc-fw.nix {
+  bldc-fw = callPackage ./bldc-fw.nix {
+    inherit fwBoards gcc-arm-embedded-7;
     src = bldcSrc;
-    inherit fwBoards;
   };
 in
-pkgs.stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = executableName;
   version = src.shortRev or src.dirtyShortRev or src.rev or src.dirtyRev or "unknown";
 
@@ -45,7 +52,7 @@ pkgs.stdenv.mkDerivation {
   };
 
   desktopItems = [
-    (pkgs.makeDesktopItem {
+    (makeDesktopItem {
       name = "com.vesc-project.";
       exec = executableName;
       icon = "vesc_tool_${kind}.svg";
@@ -83,21 +90,21 @@ pkgs.stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  buildInputs = [ pkgs.libsForQt5.qtbase ];
+  buildInputs = [ libsForQt5.qtbase ];
 
   nativeBuildInputs = [
-    pkgs.cmake
-    pkgs.libsForQt5.qtbase
-    pkgs.libsForQt5.qtquickcontrols2
-    pkgs.libsForQt5.qtgamepad
-    pkgs.libsForQt5.qtconnectivity
-    pkgs.libsForQt5.qtpositioning
-    pkgs.libsForQt5.qtserialport
-    pkgs.libsForQt5.qtgraphicaleffects
-    pkgs.libsForQt5.wrapQtAppsHook
+    cmake
+    libsForQt5.qtbase
+    libsForQt5.qtquickcontrols2
+    libsForQt5.qtgamepad
+    libsForQt5.qtconnectivity
+    libsForQt5.qtpositioning
+    libsForQt5.qtserialport
+    libsForQt5.qtgraphicaleffects
+    libsForQt5.wrapQtAppsHook
 
     # Make the desktop icon work
-    pkgs.copyDesktopItems
-    pkgs.tree
+    copyDesktopItems
+    tree
   ];
 }


### PR DESCRIPTION
Updates the flake nixpkgs input to 25.05, and fixes the errors caused by it.

Unfortunately gcc-arm-embedded-7, used when building the bldc firmwares, has been removed from nixpkgs, so we now also include an older version of it for gcc-arm-embedded-7 specifically. Simply trying to build bldc with the newer gcc version 14 breaks for some reason, with the linker giving an error about overlaping sections that I'm not knowledgeable enough to solve. And since the project does use that version specifically keeping the old version feels like the correct solution for now.

Going forwards I think the best solution would be to migrate the project to use a version of gcc-arm-embedded >= 13, but that's of course easier said than done.

I also did some minor refactoring of the nix files.