### PR TITLE
Commandline connection improvements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -77,6 +77,8 @@ static void showHelp()
 {
     qDebug() << "Arguments";
     qDebug() << "-h, --help : Show help text";
+    qDebug() << "--about : Show about text";
+    qDebug() << "--version : Show VESC Tool version information on one line";
     qDebug() << "--tcpServer [port] : Connect to VESC and start TCP server on [port]";
     qDebug() << "--loadQml [file] : Load QML UI from file instead of the regular VESC Tool UI";
     qDebug() << "--loadQmlVesc : Load QML UI from the connected VESC instead of the regular VESC Tool UI";
@@ -364,6 +366,16 @@ int main(int argc, char *argv[])
 
         if ((dash && str.contains('h')) || str == "--help") {
             showHelp();
+            return 0;
+        }
+
+        if (str == "--about") {
+            qDebug() << Utility::aboutText();
+            return 0;
+        }
+
+        if (str == "--version") {
+            qDebug() << Utility::versionText();
             return 0;
         }
 
@@ -1024,6 +1036,8 @@ int main(int argc, char *argv[])
     QmlUi *qmlUi = nullptr;
     QString qmlStr;
 
+    bool serialAutoconnect = vescPort.isEmpty();
+
     QTimer connTimer;
     connTimer.setInterval(1000);
     QObject::connect(&connTimer, &QTimer::timeout, [&]() {
@@ -1037,7 +1051,7 @@ int main(int argc, char *argv[])
             }
 
             bool ok = false;
-            if (vescPort.isEmpty()) {
+            if (serialAutoconnect) {
                 ok = vesc->autoconnect();
             } else {
                 ok = vesc->connectSerial(vescPort);
@@ -1069,6 +1083,8 @@ int main(int argc, char *argv[])
         vesc = new VescInterface;
         vesc->setBlockFwSwap(true);
         vesc->setIgnoreCustomConfigs(!isCustomConf);
+        vesc->setShowFwUpdateAvailable(false);
+        vesc->setIgnoreTestVersion(true);
 
         vesc->fwConfig()->loadParamsXml("://res/config/fw.xml");
         Utility::configLoadLatest(vesc);
@@ -1132,7 +1148,7 @@ int main(int argc, char *argv[])
         QTimer::singleShot(10, [&]() {
             int exitCode = 0;
             bool ok = false;
-            if (vescPort.isEmpty()) {
+            if (serialAutoconnect) {
                 ok = vesc->autoconnect();
             } else {
                 ok = vesc->connectSerial(vescPort);
@@ -1150,6 +1166,14 @@ int main(int argc, char *argv[])
 
                 if (canFwd >= 0) {
                     vesc->commands()->setSendCan(true, canFwd);
+                } else if (!serialAutoconnect) {
+                    //Ensure we talk to the USB connected Vesc, if no CAN id was specified and we are not autoconnecting
+                    //If autoconnecting then we will use the last CAN id in settings
+                    vesc->commands()->setSendCan(false, 0);
+                }
+
+                if (vesc->commands()->getSendCan()) {
+                    qDebug() << "Sending to CAN ID" << vesc->commands()->getCanSendId();
                 }
 
                 CodeLoader loader;

--- a/utility.cpp
+++ b/utility.cpp
@@ -257,6 +257,11 @@ QString Utility::aboutText()
             ;
 }
 
+QString Utility::versionText()
+{
+    return QString::number(VT_VERSION, 'f', 2) + "-" + QString::number(VT_IS_TEST_VERSION) + "+" + STR(VT_GIT_COMMIT);
+}
+
 QString Utility::uuid2Str(QByteArray uuid, bool space)
 {
     QString strUuid;

--- a/utility.h
+++ b/utility.h
@@ -52,6 +52,7 @@ public:
     Q_INVOKABLE static QString fwChangeLog();
     Q_INVOKABLE static QString vescToolChangeLog();
     Q_INVOKABLE static QString aboutText();
+    Q_INVOKABLE static QString versionText();
     Q_INVOKABLE static QString uuid2Str(QByteArray uuid, bool space);
     Q_INVOKABLE static bool requestFilePermission();
     Q_INVOKABLE static bool hasLocationPermission();

--- a/vescinterface.h
+++ b/vescinterface.h
@@ -267,6 +267,9 @@ public:
     bool ignoreCustomConfigs() const;
     void setIgnoreCustomConfigs(bool newIgnoreCustomConfigs);
 
+    bool ignoreTestVersion() const;
+    void setIgnoreTestVersion(bool ignore);
+
     Q_INVOKABLE bool reconnectLastCan();
     Q_INVOKABLE void setReconnectLastCan(bool set);
 
@@ -482,6 +485,7 @@ private:
     bool mSpeedGaugeUseNegativeValues;
     bool mAskQmlLoad;
     bool mIgnoreCustomConfigs;
+    bool mIgnoreTestVersion;
 
     void updateFwRx(bool fwRx);
     void setLastConnectionType(conn_t type);


### PR DESCRIPTION
- Add commands --about and --version to print some about/version info respectively.

- Fix autoconnection issue with connected CAN devices: If VESC Tool is run with a command that connects to a CAN-connected VESC over USB (for example 'vesc_tool_6.06 --vescPort /dev/ttyUSB1 --canFwd 13 ...'), and then the next time VESC Tool is run with a command for only the USB-connected VESC ('vesc_tool_6.06 --vescPort /dev/ttyUSB1 ...'), the previously connected CAN VESC will be communicated with instead. Now, behaviour is changed so that if --canFwd is not specified, connection will either proceed directly with the USB VESC (if --vescPort is specified), or autoconnect will be used to connect to the last USB/CAN VESC (if --vescPort and --canFwd are both not specified).

- On Windows, support specifying arguments to --VescPort by a partial name such as '--VescPort COM4' in addition to the full explicit path '--VescPort \\.\COM4'.

- Reduce printouts (of test version and fw update available) when running VESC Tool with commandline arguments, to aid parsing/logging program output.