### PR TITLE
Fix --queryDeviceFwParams

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1347,6 +1347,34 @@ int main(int argc, char *argv[])
                     }
                 }
 
+                if (queryDeviceFwParams) {
+                    FW_RX_PARAMS params;
+                    Utility::getFwVersionBlocking(vesc, &params);
+
+                    QString fwStr;
+                    QString strUuid = Utility::uuid2Str(params.uuid, true);
+
+                    if (params.major >= 0) {
+                        fwStr = QString("FW: V%1.%2").arg(params.major).arg(params.minor, 2, 10, QLatin1Char('0'));
+                        if (!params.fwName.isEmpty()) {
+                            fwStr += " (" + params.fwName + ")";
+                        }
+
+                        if (!params.hw.isEmpty()) {
+                            fwStr += ", Hw: " + params.hw;
+                        }
+
+                        if (!strUuid.isEmpty()) {
+                            fwStr += ", UUID: " + strUuid;
+                        }
+
+                        fwStr += ", isTestFw: " + QString::number(params.isTestFw);
+                        fwStr += ", hwType: " + params.hwTypeStr();
+                        fwStr += ", hwConfCrc: " + QString::number(params.hwConfCrc);
+                    }
+                    qInfo() << fwStr;
+                }
+
                 if (uploadBootloaderBuiltin) {
                     FW_RX_PARAMS params = vesc->getLastFwRxParams();
                     QString path = "";
@@ -1397,33 +1425,6 @@ int main(int argc, char *argv[])
                         qWarning() << "No included bootloader found.";
                         exitCode = -30;
                     }
-                }
-
-                if (queryDeviceFwParams) {
-                    FW_RX_PARAMS params = vesc->getLastFwRxParams();
-
-                    QString fwStr;
-                    QString strUuid = Utility::uuid2Str(params.uuid, true);
-
-                    if (params.major >= 0) {
-                        fwStr = QString("FW: V%1.%2").arg(params.major).arg(params.minor, 2, 10, QLatin1Char('0'));
-                        if (!params.fwName.isEmpty()) {
-                            fwStr += " (" + params.fwName + ")";
-                        }
-
-                        if (!params.hw.isEmpty()) {
-                            fwStr += ", Hw: " + params.hw;
-                        }
-
-                        if (!strUuid.isEmpty()) {
-                            fwStr += ", UUID: " + strUuid;
-                        }
-
-                        fwStr += ", isTestFw: " + QString::number(params.isTestFw);
-                        fwStr += ", hwType: " + params.hwTypeStr();
-                        fwStr += ", hwConfCrc: " + QString::number(params.hwConfCrc);
-                    }
-                    qInfo() << fwStr;
                 }
 
                 if (!firmwarePath.isEmpty()) {


### PR DESCRIPTION
Fix --queryDeviceFwParams command so that it can query any CAN-connected devices too, and do this before bootloader/FW upload.