### PR TITLE
Print sizes of the QML and Lisp payloads when building packages

### DIFF
--- a/codeloader.cpp
+++ b/codeloader.cpp
@@ -1258,6 +1258,22 @@ bool CodeLoader::createPackageFromDescription(QString path, VescPackage *pkgRes,
             file.write(packVescPackage(pkg));
             file.close();
             qDebug() << "Package saved as" << pkgOutput;
+
+            const int flashBlockSize = 128 * 1024;
+
+            if (!pkg.qmlFile.isEmpty()) {
+                int compressedQmlSize = qmlCompress(pkg.qmlFile).size();
+                qDebug().noquote() << QString("Compressed QML size : %1 / %2 bytes (%3%)")
+                            .arg(compressedQmlSize).arg(flashBlockSize)
+                            .arg(100.0 * compressedQmlSize / flashBlockSize, 0, 'f', 1);
+            }
+
+            if (!pkg.lispData.isEmpty()) {
+                int lispSize = pkg.lispData.size();
+                qDebug().noquote() << QString("Lisp data size      : %1 / %2 bytes (%3%)")
+                            .arg(lispSize).arg(flashBlockSize)
+                            .arg(100.0 * lispSize / flashBlockSize, 0, 'f', 1);
+            }
         } else {
             qWarning() << QString("Could not open %1 for writing.").arg(pkgOutput);
             result = false;

--- a/main.cpp
+++ b/main.cpp
@@ -994,6 +994,22 @@ int main(int argc, char *argv[])
         file.write(loader.packVescPackage(pkg));
         file.close();
 
+        const int flashBlockSize = 128 * 1024;
+
+        if (!pkg.qmlFile.isEmpty()) {
+            int compressedQmlSize = loader.qmlCompress(pkg.qmlFile).size();
+            qDebug().noquote() << QString("Compressed QML size : %1 / %2 bytes (%3%)")
+                        .arg(compressedQmlSize).arg(flashBlockSize)
+                        .arg(100.0 * compressedQmlSize / flashBlockSize, 0, 'f', 1);
+        }
+
+        if (!pkg.lispData.isEmpty()) {
+            int lispSize = pkg.lispData.size();
+            qDebug().noquote() << QString("Lisp data size      : %1 / %2 bytes (%3%)")
+                        .arg(lispSize).arg(flashBlockSize)
+                        .arg(100.0 * lispSize / flashBlockSize, 0, 'f', 1);
+        }
+
         qDebug() << "Package Saved!";
         return 0;
     }

--- a/mobile/ConfigPageCustom.qml
+++ b/mobile/ConfigPageCustom.qml
@@ -167,6 +167,7 @@ Item {
                     }
                     MenuItem {
                         text: "Save XML"
+                        // HERE save
                         onTriggered: {
                             if (Utility.requestFilePermission()) {
                                 fileDialogSave.close()

--- a/mobile/Packages.qml
+++ b/mobile/Packages.qml
@@ -225,6 +225,7 @@ Item {
         }
     }
 
+    // HERE install
     function openPkgDialog(pkg) {
         var line1 = pkg.description.slice(0, pkg.description.indexOf("\n"))
         if (line1.toUpperCase().includes("<!DOCTYPE HTML PUBLIC")) {

--- a/mobile/StartPage.qml
+++ b/mobile/StartPage.qml
@@ -485,6 +485,7 @@ Item {
     }
 
     Dialog {
+        // HERE Backup
         id: backupConfigDialog
         standardButtons: Dialog.Ok | Dialog.Cancel
         modal: true


### PR DESCRIPTION
Helpful to see at a glance how much space each of lisp/qml is taking up.