### PR TITLE
Support for motor disable/enable

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -284,6 +284,7 @@ void Commands::processPacket(QByteArray data)
                 quint8 status = vb.vbPopFrontUint8();
                 values.has_timeout = status & 1;
                 values.kill_sw_active = (status >> 1) & 1;
+                values.motor_disabled = (status >> 2) & 1;
             }
         }
 
@@ -1506,6 +1507,14 @@ void Commands::shutdown()
     vb.vbAppendInt8(COMM_SHUTDOWN);
     vb.vbAppendInt8(0);
     vb.vbAppendInt8(0);
+    emitData(vb);
+}
+
+void Commands::disableMotor(bool disable)
+{
+    VByteArray vb;
+    vb.vbAppendInt8(COMM_DISABLE);
+    vb.vbAppendInt8(disable ? 1 : 0);
     emitData(vb);
 }
 

--- a/commands.h
+++ b/commands.h
@@ -204,6 +204,7 @@ public slots:
     void detectMotorParam(double current, double min_rpm, double low_duty);
     void reboot();
     void shutdown();
+    void disableMotor(bool disable);
     void sendAlive();
     void getDecodedPpm();
     void getDecodedAdc();

--- a/datatypes.h
+++ b/datatypes.h
@@ -188,6 +188,7 @@ struct MC_VALUES {
     Q_PROPERTY(double vq MEMBER vq)
     Q_PROPERTY(bool has_timeout MEMBER has_timeout)
     Q_PROPERTY(bool kill_sw_active MEMBER kill_sw_active)
+    Q_PROPERTY(bool motor_disabled MEMBER motor_disabled)
 
 public:
     MC_VALUES() {
@@ -216,6 +217,7 @@ public:
         vq = 0.0;
         has_timeout = false;
         kill_sw_active = false;
+        motor_disabled = false;
     }
 
     bool operator==(const MC_VALUES &other) const {
@@ -254,6 +256,7 @@ public:
     double vq;
     bool has_timeout;
     bool kill_sw_active;
+    bool motor_disabled;
 };
 
 Q_DECLARE_METATYPE(MC_VALUES)
@@ -1038,6 +1041,8 @@ typedef enum {
     COMM_CAN_UPDATE_BAUD_ALL				= 158,
 
     COMM_MOTOR_ESTOP						= 159,
+
+    COMM_DISABLE							= 160,
 } COMM_PACKET_ID;
 
 // CAN commands

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -220,6 +220,7 @@ MainWindow::MainWindow(QWidget *parent) :
     mPreferences->setVesc(mVesc);
 
     mStatusInfoTime = 0;
+    mMotorDisabledNow = false;
     mStatusLabel = new QLabel(this);
     ui->statusBar->addPermanentWidget(mStatusLabel);
     mDebugTimer = new QTimer(this);
@@ -796,8 +797,11 @@ void MainWindow::timerSlot()
         }
     } else {
         QString str = mVesc->getConnectedPortName();
+        if (mMotorDisabledNow && mVesc->isPortConnected()) {
+            str += tr(" | MOTOR DISABLED");
+        }
         if (str != mStatusLabel->text()) {
-            mStatusLabel->setText(mVesc->getConnectedPortName());
+            mStatusLabel->setText(str);
             static QString statusLast = "";
             if (str != statusLast) {
                 mPageDebugPrint->printConsole("Status: " + str + "<br>");
@@ -1075,6 +1079,7 @@ void MainWindow::valuesReceived(MC_VALUES values, unsigned int mask)
     (void)mask;
     ui->dispCurrent->setVal(values.current_motor);
     ui->dispDuty->setVal(values.duty_now * 100.0);
+    mMotorDisabledNow = values.motor_disabled;
 }
 
 void MainWindow::paramChangedDouble(QObject *src, QString name, double newParam)
@@ -1116,6 +1121,25 @@ void MainWindow::on_actionReboot_triggered()
 void MainWindow::on_actionShutdown_triggered()
 {
     mVesc->commands()->shutdown();
+}
+
+void MainWindow::on_actionMotorDisable_triggered()
+{
+    QMessageBox::StandardButton answer = QMessageBox::question(
+                this,
+                tr("Disable Motor"),
+                tr("This will disable the motor until it is enabled again. Continue?"),
+                QMessageBox::Yes | QMessageBox::Cancel
+                );
+
+    if (answer == QMessageBox::Yes) {
+        mVesc->commands()->disableMotor(true);
+    }
+}
+
+void MainWindow::on_actionMotorEnable_triggered()
+{
+    mVesc->commands()->disableMotor(false);
 }
 
 void MainWindow::on_stopButton_clicked()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -104,6 +104,8 @@ private slots:
     void on_actionDisconnect_triggered();
     void on_actionReboot_triggered();
     void on_actionShutdown_triggered();
+    void on_actionMotorDisable_triggered();
+    void on_actionMotorEnable_triggered();
     void on_stopButton_clicked();
     void on_fullBrakeButton_clicked();
     void on_actionReadMcconf_triggered();
@@ -177,6 +179,7 @@ private:
     QTimer *mTimer;
     QLabel *mStatusLabel;
     int mStatusInfoTime;
+    bool mMotorDisabledNow;
     bool mKeyLeft;
     bool mKeyRight;
     bool mMcConfRead;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -673,6 +673,10 @@
     <addaction name="separator"/>
     <addaction name="actionReboot"/>
     <addaction name="actionShutdown"/>
+    <addaction name="separator"/>
+    <addaction name="actionMotorDisable"/>
+    <addaction name="actionMotorEnable"/>
+    <addaction name="separator"/>
     <addaction name="actionRestartLispBM"/>
    </widget>
    <widget class="QMenu" name="menuCommands">
@@ -769,6 +773,22 @@
    </property>
    <property name="toolTip">
     <string>Shutdown (for controllers with auto-shutdown support only)</string>
+   </property>
+  </action>
+  <action name="actionMotorDisable">
+   <property name="text">
+    <string>Disable Motor</string>
+   </property>
+   <property name="toolTip">
+    <string>Disable the motor persistently (survives reboots). Only works while the motor is stationary.</string>
+   </property>
+  </action>
+  <action name="actionMotorEnable">
+   <property name="text">
+    <string>Enable Motor</string>
+   </property>
+   <property name="toolTip">
+    <string>Re-enable the motor after Disable Motor</string>
    </property>
   </action>
   <action name="actionCanFwd">

--- a/mobile/RtData.qml
+++ b/mobile/RtData.qml
@@ -226,7 +226,8 @@ Item {
                     "Wh Draw    : " + parseFloat(values.watt_hours).toFixed(2) + " Wh\n" +
                     "Wh Charge  : " + parseFloat(values.watt_hours_charged).toFixed(2) + " Wh\n" +
                     "ABS Tacho  : " + values.tachometer_abs + " Counts\n" +
-                    "Fault      : " + values.fault_str
+                    "Fault      : " + values.fault_str +
+                    (values.motor_disabled ? "\nDisabled   : TRUE" : "")
         }
     }
 }

--- a/mobile/Terminal.qml
+++ b/mobile/Terminal.qml
@@ -119,10 +119,54 @@ Item {
                         }
                     }
                     MenuItem {
+                        text: "Disable Motor"
+                        onTriggered: {
+                            motorDisableDialog.open()
+                        }
+                    }
+                    MenuItem {
+                        text: "Enable Motor"
+                        onTriggered: {
+                            mCommands.disableMotor(false)
+                        }
+                    }
+                    MenuItem {
                         text: "Restart LispBM"
                         onTriggered: {
                             mCommands.lispSetRunning(1)
                         }
+                    }
+                }
+
+                Dialog {
+                    id: motorDisableDialog
+                    standardButtons: Dialog.Yes | Dialog.Cancel
+                    modal: true
+                    focus: true
+                    width: parent.width - 20
+                    height: 200
+                    closePolicy: Popup.CloseOnEscape
+                    title: "Disable Motor"
+                    x: 10
+                    y: 10 + parent.height / 2 - height / 2
+                    parent: terminalPageItem
+
+                    Overlay.modal: Rectangle {
+                        color: "#AA000000"
+                    }
+
+                    Text {
+                        color: Utility.getAppHexColor("lightText")
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.fill: parent
+                        wrapMode: Text.WordWrap
+                        text: "This is going to disable the motor until it is enabled again, " +
+                              "even after reboot. The command is ignored while the motor is " +
+                              "spinning. Are you sure?"
+                    }
+
+                    onAccepted: {
+                        mCommands.disableMotor(true)
                     }
                 }
             }

--- a/mobile/main.qml
+++ b/mobile/main.qml
@@ -32,6 +32,7 @@ import Vedder.vesc.vesc3ditem 1.0
 ApplicationWindow {
     id: appWindow
     property Commands mCommands: VescIf.commands()
+    property bool motorDisabledNow: false
     property ConfigParams mMcConf: VescIf.mcConfig()
     property ConfigParams mAppConf: VescIf.appConfig()
     property ConfigParams mInfoConf: VescIf.infoConfig()
@@ -820,8 +821,12 @@ ApplicationWindow {
         running: true
         repeat: true
         onTriggered: {
-            if (!statusTimer.running && connectedText.text !== VescIf.getConnectedPortName()) {
-                connectedText.text = VescIf.getConnectedPortName()
+            var statusStr = VescIf.getConnectedPortName()
+            if (appWindow.motorDisabledNow && VescIf.isPortConnected()) {
+                statusStr += " | MOTOR DISABLED"
+            }
+            if (!statusTimer.running && connectedText.text !== statusStr) {
+                connectedText.text = statusStr
             }
         }
     }
@@ -1183,6 +1188,10 @@ ApplicationWindow {
 
     Connections {
         target: mCommands
+        function onValuesReceived(values, mask) {
+            appWindow.motorDisabledNow = values.motor_disabled
+        }
+
         function onValuesImuReceived(values, mask) {
             if (tabBar.currentIndex == (1 + indexOffset()) && rtSwipeView.currentIndex == 2) {
                 vesc3dLoader.item.setRotation(values.roll, values.pitch,

--- a/widgets/rtdatatext.cpp
+++ b/widgets/rtdatatext.cpp
@@ -82,6 +82,7 @@ void RtDataText::paintEvent(QPaintEvent *event)
                                     "T\n"
                                     "T\n"
                                     "T\n"
+                                    "T\n"
                                     "T\n");
 
     int boxh_new = br.height();
@@ -128,11 +129,13 @@ void RtDataText::paintEvent(QPaintEvent *event)
     str = QString::asprintf("T FET   : %.2f \u00B0C\n"
                 "T Motor : %.2f \u00B0C\n"
                 "Fault   : %s\n"
+                "%s"
                 "Tac     : %i\n"
                 "Tac ABS : %i\n",
                 mValues.temp_mos,
                 mValues.temp_motor,
                 mValues.fault_str.toLocal8Bit().data(),
+                mValues.motor_disabled ? "Disabled: TRUE\n" : "",
                 mValues.tachometer,
                 mValues.tachometer_abs);
 

--- a/widgets/rtdatatext.cpp
+++ b/widgets/rtdatatext.cpp
@@ -126,6 +126,10 @@ void RtDataText::paintEvent(QPaintEvent *event)
                      Qt::AlignLeft, str);
 
     // Middle info box
+    bool fault_active = mValues.fault_code != FAULT_CODE_NONE;
+
+    // The fault value and the TRUE of the disabled row are left out here and
+    // drawn separately in red below.
     str = QString::asprintf("T FET   : %.2f \u00B0C\n"
                 "T Motor : %.2f \u00B0C\n"
                 "Fault   : %s\n"
@@ -134,8 +138,8 @@ void RtDataText::paintEvent(QPaintEvent *event)
                 "Tac ABS : %i\n",
                 mValues.temp_mos,
                 mValues.temp_motor,
-                mValues.fault_str.toLocal8Bit().data(),
-                mValues.motor_disabled ? "Disabled: TRUE\n" : "",
+                fault_active ? "" : mValues.fault_str.toLocal8Bit().data(),
+                mValues.motor_disabled ? "Disabled: \n" : "",
                 mValues.tachometer,
                 mValues.tachometer_abs);
 
@@ -143,9 +147,30 @@ void RtDataText::paintEvent(QPaintEvent *event)
     painter.fillRect(vidw / 2.0 - bbox_w / 2.0, 0, bbox_w, bbow_h, Utility::getAppQColor("normalBackground"));
     painter.setOpacity(1.0);
 
+    const double xmid = vidw / 2.0 - bbox_w / 2.0 + mTxtOfs;
+
     painter.setPen(Utility::getAppQColor("normalText"));
-    painter.drawText(QRectF(vidw / 2.0 - bbox_w / 2.0 + mTxtOfs, mTxtOfs, mBoxW, mBoxH),
+    painter.drawText(QRectF(xmid, mTxtOfs, mBoxW, mBoxH),
                      Qt::AlignLeft, str);
+
+    if (fault_active || mValues.motor_disabled) {
+        QFontMetrics fm = painter.fontMetrics();
+        painter.setPen(Utility::getAppQColor("red"));
+
+        if (fault_active) {
+            painter.drawText(QRectF(xmid + fm.horizontalAdvance("Fault   : "),
+                                    mTxtOfs + 2 * fm.lineSpacing(), mBoxW, mBoxH),
+                             Qt::AlignLeft, mValues.fault_str);
+        }
+
+        if (mValues.motor_disabled) {
+            painter.drawText(QRectF(xmid + fm.horizontalAdvance("Disabled: "),
+                                    mTxtOfs + 3 * fm.lineSpacing(), mBoxW, mBoxH),
+                             Qt::AlignLeft, "TRUE");
+        }
+
+        painter.setPen(Utility::getAppQColor("normalText"));
+    }
 
     // Right info box
     str = QString::asprintf("Ah Draw   : %.1f mAh\n"


### PR DESCRIPTION
Two commits:
-first one adds support for showing the "motor disabled" state (status bar and RT Data) as well as terminal menu items to Disable/Enable the motor
-second commit (optional) shows both the fault string and "TRUE" for Disabled in red

Desktop build fully tested, mobile app is not tested (I currently can't build it for some reason)