### PR TITLE
General Nix Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ nix develop
 
 Then follow the normal build instructions for Linux.
 
-**Note:** The Nix flake's outputs currently only supports x86 Linux.
-
 ### Starting QT Creator in Nix
 
 QT Creator allows you to easily build and run the project. It also allows you to edit the page UIs with it's graphical editor. To run it using Nix simply start QT Creator from a shell with the build dependencies:

--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1735554305,
-        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "bldcSrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1733324381,
-        "narHash": "sha256-ui9N8QSog1G5zyK7yRrD0Xl+Y2CZhvvhBkaJuQZ2qZw=",
+        "lastModified": 1786613032,
+        "narHash": "sha256-ZnYvTR6wqEeUcalsUJmvICpqdmZIto1RTscgeaQO7Os=",
         "owner": "vedderb",
         "repo": "bldc",
-        "rev": "a0d40e2c5a42c810888d8c379307e6b0a118a125",
+        "rev": "b9d287b3b8323f4b02618b02dc55e57d54a84996",
         "type": "github"
       },
       "original": {
         "owner": "vedderb",
-        "ref": "release_6_05",
+        "ref": "master",
         "repo": "bldc",
         "type": "github"
       }
@@ -51,22 +51,6 @@
         "type": "github"
       }
     },
-    "nixpkgsOld": {
-      "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1770107345,
@@ -88,7 +72,6 @@
         "bldcSrc": "bldcSrc",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgsOld": "nixpkgsOld",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748302896,
-        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
+        "lastModified": 1787204541,
+        "narHash": "sha256-OURZPknrTjQrlNyxPdqzyqmU/81Wes1CUP/Ft1Rv/YI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
+        "rev": "5880666fd9eb563038431edb35c2d0aa595884e6",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       treefmt-nix,
       bldcSrc,
     }@inputs:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+    flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Packages VESC Tool into a flake.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     # gcc-arm-embedded-7 has been removed from nixpkgs since 25.05 since it's
     # old and unmaintained. However, this project still uses that version, so we
     # include an older version of nixpkgs to access it.

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
-    # gcc-arm-embedded-7 has been removed from nixpkgs since 25.05 since it's
-    # old and unmaintained. However, this project still uses that version, so we
-    # include an older version of nixpkgs to access it.
-    nixpkgsOld.url = "github:nixos/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     bldcSrc = {
-      url = "github:vedderb/bldc/release_6_05";
+      url = "github:vedderb/bldc/master";
       flake = false;
     };
   };
@@ -20,7 +16,6 @@
     {
       self,
       nixpkgs,
-      nixpkgsOld,
       flake-utils,
       treefmt-nix,
       bldcSrc,
@@ -35,7 +30,6 @@
         selfPkgs = import ./pkgs {
           inherit pkgs bldcSrc;
           src = self;
-          gcc-arm-embedded-7 = nixpkgsOld.legacyPackages.${system}.gcc-arm-embedded-7;
         };
       in
       {
@@ -54,7 +48,7 @@
     )
     // {
       overlays.default = (nixpkgs.lib.makeOverridable (import ./overlay.nix)) {
-        inherit bldcSrc nixpkgsOld;
+        inherit bldcSrc;
         src = self;
       };
       # For development in the nix repl

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,8 +3,6 @@
   src,
   bldcSrc,
   fwBoards ? [ ],
-
-  gcc-arm-embedded-7,
 }:
 rec {
   vesc-tool = pkgs.callPackage ./vesc-tool {
@@ -12,7 +10,6 @@ rec {
       src
       bldcSrc
       fwBoards
-      gcc-arm-embedded-7
       ;
     kind = "original";
   };
@@ -24,7 +21,7 @@ rec {
   vesc-tool-free = vesc-tool.override { kind = "free"; };
 
   bldc-fw = pkgs.callPackage ./vesc-tool/bldc-fw.nix {
-    inherit fwBoards gcc-arm-embedded-7;
+    inherit fwBoards;
     src = bldcSrc;
   };
 }

--- a/pkgs/vesc-tool/bldc-fw.nix
+++ b/pkgs/vesc-tool/bldc-fw.nix
@@ -6,7 +6,7 @@
   # Can also be the string "all", which builds all standard board firmwares.
   fwBoards ? [ ],
 
-  gcc-arm-embedded-7,
+  gcc-arm-embedded-14,
   git,
   python3,
   stdenv,
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    gcc-arm-embedded-7
+    gcc-arm-embedded-14
     python3
     git
   ];

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -12,7 +12,6 @@
   callPackage,
   cmake,
   copyDesktopItems,
-  gcc-arm-embedded-7,
   libsForQt5,
   makeDesktopItem,
   stdenv,
@@ -38,7 +37,7 @@ let
     .${kind};
 
   bldc-fw = callPackage ./bldc-fw.nix {
-    inherit fwBoards gcc-arm-embedded-7;
+    inherit fwBoards;
     src = bldcSrc;
   };
 in

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -24,6 +24,7 @@ let
     (lib.toUpper (builtins.substring 0 1 str)) + (builtins.substring 1 (builtins.stringLength str) str);
   kindTitleCase = firstToUpper kind;
   executableName = "vesc_tool${if kind == "original" then "" else "_${kind}"}";
+  releaseConfig = if stdenv.hostPlatform.isDarwin then "release_macos" else "release_lin";
   iconPath =
     {
       "original" = "res/version/neutral_v.svg";
@@ -65,7 +66,7 @@ stdenv.mkDerivation {
   inherit src;
 
   configurePhase = ''
-    qmake -config release "CONFIG += release_lin build_${kind}"
+    qmake -config release "CONFIG += ${releaseConfig} build_${kind}"
   '';
   buildPhase = ''
     mkdir -p ./res/firmwares/

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "VESC Tool ${kind}, an IDE for controlling and configuring VESC-compatible motor controllers and other devices.";
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 
   desktopItems = [

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -25,6 +25,9 @@ let
   kindTitleCase = firstToUpper kind;
   executableName = "vesc_tool${if kind == "original" then "" else "_${kind}"}";
   releaseConfig = if stdenv.hostPlatform.isDarwin then "release_macos" else "release_lin";
+  qmakePlatformArgs = lib.optionalString stdenv.hostPlatform.isDarwin (
+    "-after QMAKE_APPLE_DEVICE_ARCHS=${stdenv.hostPlatform.darwinArch}"
+  );
   iconPath =
     {
       "original" = "res/version/neutral_v.svg";
@@ -66,7 +69,7 @@ stdenv.mkDerivation {
   inherit src;
 
   configurePhase = ''
-    qmake -config release "CONFIG += ${releaseConfig} build_${kind}"
+    qmake -config release "CONFIG += ${releaseConfig} build_${kind}" ${qmakePlatformArgs}
   '';
   buildPhase = ''
     mkdir -p ./res/firmwares/

--- a/pkgs/vesc-tool/default.nix
+++ b/pkgs/vesc-tool/default.nix
@@ -76,19 +76,30 @@ stdenv.mkDerivation {
 
     make -j$NIX_BUILD_CORES
   '';
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
 
-    mkdir -p \
-      $out/bin \
-      $out/share/icons/hicolor/scalable/apps
+        mkdir -p $out/Applications
+        cp -R "build/macos/VESC Tool.app" $out/Applications/
 
-    cp build/lin/vesc_tool_* $out/bin/${executableName}
-    cp ${iconPath} $out/share/icons/hicolor/scalable/apps/vesc_tool_${kind}.svg
-    echo $desktopItems
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
 
-    runHook postInstall
-  '';
+        mkdir -p \
+          $out/bin \
+          $out/share/icons/hicolor/scalable/apps
+
+        cp build/lin/vesc_tool_* $out/bin/${executableName}
+        cp ${iconPath} $out/share/icons/hicolor/scalable/apps/vesc_tool_${kind}.svg
+        echo $desktopItems
+
+        runHook postInstall
+      '';
 
   buildInputs = [ libsForQt5.qtbase ];
 


### PR DESCRIPTION
We have a nix flake support and I appreciate that! Here's some maintenance for it.

Confirmed building on x86_64-linux and aarch64-darwin. Use `nix build github:MilesBreslin/vesc_tool/mbreslin/nix_maintenance#` to test locally.
﻿﻿
### flake.nix: Update nixpkgs to 26.05

General maintenance. Update the build packages to keep up with the
latest release.

### flake.nix: Update treefmt-nix

General maintenance to stay up-to-date with the latest treefmt-nix.

### flake.nix: Track bldc master branch

bldc master branch has moved to gcc 14. We no longer need to support a
hack to get gcc 7 pulled in. This removes nixpkgsOld and all references
to it.

### flake.nix: Add build targets for all nix systems

Support attempting to build these packages on all nix-supported
platforms. This allows a developer to request a build, even on an
unsupported platform, which would be rejected by meta.platforms with
a prettier error message. bldc-fw is a cross-compiled target, so it
in-particular should build nicely on any platform.

Previously, GCC 7 was used, which was only ever packaged by nixpkgs as
x86_64-linux. Now that this is using GCC 14, that's no longer holding
this back.

This adds support for systems like: aarch64-linux, x86_64-darwin,
aarch64-darwin.

### vesc-tool: Select release config by platform

Use the macOS qmake release configuration on Darwin while preserving
the Linux configuration on other supported hosts.

### pkgs/vesc-tool: Install the Darwin application bundle

The package formats for macOS and Linux are very different. Change the
installPhase to reflect that. Copy the app bundle produced by the macOS
release configuration into the conventional Nix Applications directory.
Keep the existing binary and desktop-file installation behavior for
Linux.

### pkgs/vesc-tool: Build the native Darwin architecture

Override the universal qmake configuration with the Nix target
architecture. This lets Darwin builds link against the matching
single-architecture Qt libraries.

### pkgs/vesc-tool: Mark Darwin/macOS as a supported platform

Nix on macOS succesfully builds now. Mark it as supported.

Darwin support requires the sandbox to be set to relaxed due to a
requirement from the QT nix configuration.

